### PR TITLE
toggle the display of the scope's children when a scope object is clicked

### DIFF
--- a/src/js/TreeView.js
+++ b/src/js/TreeView.js
@@ -133,6 +133,12 @@ NGI.TreeView = (function() {
 		// console.log the DOM Node this scope is attached to
 		item.label.addEventListener('click', function() {
 			console.log(item.node);
+			item.drawer.isVisible = !item.drawer.isVisible;
+			if (item.drawer.isVisible){
+		 		item.drawer.style.display = 'block';
+			} else {
+				item.drawer.style.dispay = 'none';
+			}
 		});
 
 		return item;


### PR DESCRIPTION
Obviously not the way you'd _actually_ want to build it, -- probably should be a plus/minus icon and it only triggers then since click shows the object.

Just thought I'd show a marginal level of commitment to the feature's importance to me :)
