### PR TITLE
Add right margin to HTML tag to make room for inspector pane

### DIFF
--- a/ng-inspector.chrome/ng-inspector.js
+++ b/ng-inspector.chrome/ng-inspector.js
@@ -277,6 +277,8 @@ NGI.InspectorAgent = (function() {
 
 NGI.InspectorPane = function() {
 
+  var inspectorPane = this;
+
 	// The width of the pane can be resized by the user, and is persisted via
 	// localStorage
 	var inspectorWidth = localStorage.getItem('ng-inspector-width') || 300;
@@ -311,8 +313,10 @@ NGI.InspectorPane = function() {
 	// Toggle the inspector pane on and off. Returns a boolean representing the
 	// new visibility state.
 	this.toggle = function() {
+    this.visible = !pane.parentNode;
+    resizeClientView();
+
 		if ( pane.parentNode ) {
-			this.visible = false;
 			document.body.removeChild(pane);
 			this.clear();
 			document.removeEventListener('mousemove', onMouseMove);
@@ -321,7 +325,6 @@ NGI.InspectorPane = function() {
 			window.removeEventListener('resize', onResize);
 			return false;
 		} else {
-			this.visible = true;
 			document.body.appendChild(pane);
 			document.addEventListener('mousemove', onMouseMove);
 			document.addEventListener('mousedown', onMouseDown);
@@ -350,6 +353,11 @@ NGI.InspectorPane = function() {
 	// are considered within the resize handle
 	var LEFT_RESIZE_HANDLE_PAD = 3;
 	var RIGHT_RESIZE_HANDLE_PAD = 2;
+
+  function resizeClientView() {
+    var root = document.getElementsByTagName('html')[0];
+    root.style.marginRight = inspectorPane.visible ? pane.style.width : 0;
+  }
 
 	// Listen for mousemove events in the page body, setting the canResize state
 	// if the mouse hovers close to the 
@@ -385,6 +393,7 @@ NGI.InspectorPane = function() {
 			}
 
 			pane.style.width = width + 'px';
+      resizeClientView();
 		}
 	}
 
@@ -415,6 +424,7 @@ NGI.InspectorPane = function() {
 	function onResize() {
 		if (pane.offsetWidth >= document.body.offsetWidth - 50) {
 			pane.style.width = (document.body.offsetWidth - 50) + 'px';
+      resizeClientView();
 		}
 	}
 

--- a/ng-inspector.safariextension/ng-inspector.js
+++ b/ng-inspector.safariextension/ng-inspector.js
@@ -311,8 +311,10 @@ NGI.InspectorPane = function() {
 	// Toggle the inspector pane on and off. Returns a boolean representing the
 	// new visibility state.
 	this.toggle = function() {
+    this.visible = !pane.parentNode;
+    resizeClientView();
+
 		if ( pane.parentNode ) {
-			this.visible = false;
 			document.body.removeChild(pane);
 			this.clear();
 			document.removeEventListener('mousemove', onMouseMove);
@@ -321,7 +323,6 @@ NGI.InspectorPane = function() {
 			window.removeEventListener('resize', onResize);
 			return false;
 		} else {
-			this.visible = true;
 			document.body.appendChild(pane);
 			document.addEventListener('mousemove', onMouseMove);
 			document.addEventListener('mousedown', onMouseDown);
@@ -350,6 +351,11 @@ NGI.InspectorPane = function() {
 	// are considered within the resize handle
 	var LEFT_RESIZE_HANDLE_PAD = 3;
 	var RIGHT_RESIZE_HANDLE_PAD = 2;
+
+  function resizeClientView() {
+    var root = document.getElementsByTagName('html')[0];
+    root.style.marginRight = inspectorPane.visible ? pane.style.width : 0;
+  }
 
 	// Listen for mousemove events in the page body, setting the canResize state
 	// if the mouse hovers close to the 
@@ -385,6 +391,7 @@ NGI.InspectorPane = function() {
 			}
 
 			pane.style.width = width + 'px';
+      resizeClientView();
 		}
 	}
 
@@ -415,6 +422,7 @@ NGI.InspectorPane = function() {
 	function onResize() {
 		if (pane.offsetWidth >= document.body.offsetWidth - 50) {
 			pane.style.width = (document.body.offsetWidth - 50) + 'px';
+      resizeClientView();
 		}
 	}
 


### PR DESCRIPTION
I'm wondering if this functionality was considered and then rejected depending on the possible mutilation of the user's stylesheet, but I think just modifying `margin-right` of the `<html>` tag is not too intrusive. An example:

Before:
![image](https://cloud.githubusercontent.com/assets/38674/3185253/fe43824c-ec90-11e3-9ab4-42c90b0766e9.png)

After:
![image](https://cloud.githubusercontent.com/assets/38674/3185255/06c97642-ec91-11e3-9ed4-579697670cd7.png)

Really helps with smaller displays!
