### PR TITLE
Take care of supernumerous $destroy events

### DIFF
--- a/src/js/TreeView.js
+++ b/src/js/TreeView.js
@@ -69,7 +69,9 @@ NGI.TreeView = (function() {
 		};
 
 		this.destroy = function() {
-			this.element.parentNode.removeChild(this.element);
+			if (this.element.parentNode) {
+				this.element.parentNode.removeChild(this.element);
+			}
 		};
 
 		// Pill indicator


### PR DESCRIPTION
See issue #30

Should avoid errors like: 

```
TypeError: Cannot read property 'removeChild' of null
    at TreeViewItem.destroy (chrome-extension://aadgmnobpdmgmigaicncghmmoeflnamj/ng-inspector.js:494:27)
    at chrome-extension://aadgmnobpdmgmigaicncghmmoeflnamj/ng-inspector.js:1190:11
    at Scope.$broadcast (http://localhost/OutlinerModel/lib/angular/angular.js:13082:28)
    at Scope.$destroy (http://localhost/OutlinerModel/lib/angular/angular.js:12734:14)
   ...
```
