### PR TITLE
Simple support for shortcuts (Safari)

### DIFF
--- a/ng-inspector.safariextension/ng-inspector.js
+++ b/ng-inspector.safariextension/ng-inspector.js
@@ -139,7 +139,7 @@ NGI.InspectorAgent = (function() {
 					// TreeViewItem
 					if ($node.isolateScope) {
 						var $isolate = $node.isolateScope();
-						if ($isolate) {	
+						if ($isolate) {
 							var isolateMatch = NGI.Scope.get($isolate.$id);
 							if (isolateMatch) {
 								isolateMatch.setNode(node);
@@ -166,7 +166,7 @@ NGI.InspectorAgent = (function() {
 			if (--nodeQueue === 0) {
 				// Done
 			}
-			
+
 		}
 	}
 
@@ -216,7 +216,7 @@ NGI.InspectorAgent = (function() {
 
 			// Once the Scope traversal is complete, the DOM traversal starts
 			traverseDOM(app, app.node);
-			
+
 		});
 	};
 
@@ -352,7 +352,7 @@ NGI.InspectorPane = function() {
 	var RIGHT_RESIZE_HANDLE_PAD = 2;
 
 	// Listen for mousemove events in the page body, setting the canResize state
-	// if the mouse hovers close to the 
+	// if the mouse hovers close to the
 	function onMouseMove(event) {
 
 		// Don't do anything if the inspector is detached from the DOM
@@ -370,7 +370,7 @@ NGI.InspectorPane = function() {
 			canResize = false;
 			document.body.classList.remove('ngi-resize');
 		}
-		
+
 		// If the user is currently performing a resize, the width is adjusted
 		// based on the cursor position
 		if (isResizing) {
@@ -398,7 +398,7 @@ NGI.InspectorPane = function() {
 			document.body.classList.add('ngi-resizing');
 		}
 	}
-	
+
 
 	// Listen to mouseup events on the page, turning off the resize mode if one
 	// is underway. The inspector width is then persisted in the localStorage
@@ -491,7 +491,9 @@ NGI.TreeView = (function() {
 		};
 
 		this.destroy = function() {
-			this.element.parentNode.removeChild(this.element);
+			if (this.element.parentNode) {
+				this.element.parentNode.removeChild(this.element);
+			}
 		};
 
 		// Pill indicator
@@ -612,6 +614,7 @@ NGI.TreeView = (function() {
 
 })();
 
+
 /* global NGI */
 /* jshint strict: false */
 /* jshint expr: true */
@@ -706,7 +709,7 @@ NGI.Service = (function() {
 		this.definition = invoke[2];
 		this.name = (typeof this.definition[0] === typeof '') ? this.definition[0] : null;
 		this.factory = this.definition[1];
-		
+
 		switch(this.provider) {
 			case '$compileProvider':
 				var dir = app.$injector.invoke(this.factory);
@@ -854,7 +857,7 @@ NGI.App = (function(window) {
 		this.node = node;
 
 		this.$injector = window.angular.element(node).data('$injector');
-		
+
 		if (!modules) {
 			modules = [];
 		} else if (typeof modules === typeof '') {
@@ -1105,7 +1108,7 @@ NGI.ModelMixin = (function() {
 			this.modelObjs[key].view.destroy();
 			delete this.modelObjs[key];
 		}
-		
+
 		// New keys
 		for (i = 0; i < diff.added.length; i++) {
 			key = diff.added[i];
@@ -1450,4 +1453,12 @@ window.addEventListener('message', function (event) {
 	}
 
 }, false);
+
+// Listen for alt+cmd+x
+window.addEventListener('keydown', function (event) {
+	if (event.target.nodeName.toLowerCase() !== 'input' && event.altKey && event.metaKey && event.keyCode == "88") {
+		window.ngInspector.toggle();
+	}
+});
+
 })(window);


### PR DESCRIPTION
Toggle ng-inspector panel with cmd+alt+x. In my opinion another icon in toolbar with single action is unnecessary.