### PR TITLE
Fix for issue #46 (use strict)

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -100,7 +100,7 @@ gulp.task('build:js', function() {
 		'src/js/bootstrap.js'
 	])
 		.pipe(concat('ng-inspector.js', {newLine:"\n\n"}))
-		.pipe(wrap("\"use strict\";\n(function(window) {\n<%= contents %>\n})(window);"), {variable:'data'})
+		.pipe(wrap("(function(window) {\n\"use strict\";\n\n<%= contents %>\n})(window);"), {variable:'data'})
 		.pipe(gulp.dest('ng-inspector.safariextension/'))
 		.pipe(gulp.dest('ng-inspector.chrome/'))
 		.pipe(gulp.dest('test/e2e/scenarios/lib/'));

--- a/ng-inspector.chrome/ng-inspector.js
+++ b/ng-inspector.chrome/ng-inspector.js
@@ -1,5 +1,6 @@
-"use strict";
 (function(window) {
+"use strict";
+
 /* jshint strict: false */
 
 var NGI = {};

--- a/ng-inspector.safariextension/ng-inspector.js
+++ b/ng-inspector.safariextension/ng-inspector.js
@@ -1,5 +1,6 @@
-"use strict";
 (function(window) {
+"use strict";
+
 /* jshint strict: false */
 
 var NGI = {};

--- a/test/e2e/scenarios/lib/ng-inspector.js
+++ b/test/e2e/scenarios/lib/ng-inspector.js
@@ -1,5 +1,6 @@
-"use strict";
 (function(window) {
+"use strict";
+
 /* jshint strict: false */
 
 var NGI = {};


### PR DESCRIPTION
Description of the problem/cause can be seen in issue #46. I've verified the E2E tests pass, and the extension still appears to be functional in both Safari and Chrome.

A small change is also in 297e9f8 to the built ng-inspector.js files. It looks like those updates didn't make it into the built files from a previous committer.