### PR TITLE
Force direction: LTR

### DIFF
--- a/ng-inspector.chrome/stylesheet.css
+++ b/ng-inspector.chrome/stylesheet.css
@@ -36,6 +36,7 @@ body.ngi-resizing {
   height: 100vh;
   width: 300px;
   z-index: 999999999999;
+  direction: ltr;
   /* Styling */
   background: #D8D8D8 !important;
   border-left: 1px solid #B0B0B0 !important;


### PR DESCRIPTION
Developing in an RTL web means that an upper tag, such as `html` or `body` has a `direction: rtl` that cascades all the way down, including ngInspector.