### PR TITLE
Better panel placement

### DIFF
--- a/ng-inspector.chrome/ng-inspector.js
+++ b/ng-inspector.chrome/ng-inspector.js
@@ -311,22 +311,26 @@ NGI.InspectorPane = function() {
 	// Toggle the inspector pane on and off. Returns a boolean representing the
 	// new visibility state.
 	this.toggle = function() {
+		var events = {
+			mousemove: {fn: onMouseMove, target: document},
+			mousedown: {fn: onMouseDown, target: document},
+			mouseup: {fn: onMouseUp, target: document},
+			resize: {fn: onResize, target: window}
+		};
 		if ( pane.parentNode ) {
 			this.visible = false;
 			document.body.removeChild(pane);
 			this.clear();
-			document.removeEventListener('mousemove', onMouseMove);
-			document.removeEventListener('mousedown', onMouseDown);
-			document.removeEventListener('mouseup', onMouseUp);
-			window.removeEventListener('resize', onResize);
+			Object.keys(events).forEach(function(key) {
+				events[key].target.removeEventListener(key, events[key].fn);
+			});
 			return false;
 		} else {
 			this.visible = true;
 			document.body.appendChild(pane);
-			document.addEventListener('mousemove', onMouseMove);
-			document.addEventListener('mousedown', onMouseDown);
-			document.addEventListener('mouseup', onMouseUp);
-			window.addEventListener('resize', onResize);
+			Object.keys(events).forEach(function(key) {
+				events[key].target.addEventListener(key, events[key].fn);
+			});
 			return true;
 		}
 	};

--- a/ng-inspector.chrome/ng-inspector.js
+++ b/ng-inspector.chrome/ng-inspector.js
@@ -281,6 +281,9 @@ NGI.InspectorPane = function() {
 	// localStorage
 	var inspectorWidth = localStorage.getItem('ng-inspector-width') || 300;
 
+	// Quicker reference to body through-out InspectorPane lexical scope
+	var body = document.body;
+
 	// Create the root DOM node for the inspector pane
 	var pane = document.createElement('div');
 	pane.className = 'ngi-inspector';
@@ -317,23 +320,26 @@ NGI.InspectorPane = function() {
 			mouseup: {fn: onMouseUp, target: document},
 			resize: {fn: onResize, target: window}
 		};
+
 		if ( pane.parentNode ) {
-			this.visible = false;
-			document.body.removeChild(pane);
-			document.body.classList.remove('ngi-open');
+			body.removeChild(pane);
+			body.classList.remove('ngi-open');
+			setStyleProps(body, {
+				'width': '100%',
+				'margin-right': 0
+			});
 			this.clear();
-			Object.keys(events).forEach(function(key) {
-				events[key].target.removeEventListener(key, events[key].fn);
-			});
-			return false;
+			eventListenerBulk(events, true);
+			return this.visible = false;;
 		} else {
-			this.visible = true;
-			document.body.appendChild(pane);
-			document.body.classList.add('ngi-open');
-			Object.keys(events).forEach(function(key) {
-				events[key].target.addEventListener(key, events[key].fn);
+			body.appendChild(pane);
+			body.classList.add('ngi-open');
+			setStyleProps(body, {
+				'width': 'calc(100% - ' + pane.offsetWidth + 'px)',
+				'margin-right': pane.offsetWidth + 'px'
 			});
-			return true;
+			eventListenerBulk(events, false);
+			return this.visible = true;
 		}
 	};
 
@@ -379,10 +385,10 @@ NGI.InspectorPane = function() {
 		if (pane.offsetLeft - LEFT_RESIZE_HANDLE_PAD <= event.clientX &&
 			event.clientX <= pane.offsetLeft + RIGHT_RESIZE_HANDLE_PAD) {
 			canResize = true;
-			document.body.classList.add('ngi-resize');
+			body.classList.add('ngi-resize');
 		} else {
 			canResize = false;
-			document.body.classList.remove('ngi-resize');
+			body.classList.remove('ngi-resize');
 		}
 		
 		// If the user is currently performing a resize, the width is adjusted
@@ -409,7 +415,7 @@ NGI.InspectorPane = function() {
 	function onMouseDown() {
 		if (canResize) {
 			isResizing = true;
-			document.body.classList.add('ngi-resizing');
+			body.classList.add('ngi-resizing');
 		}
 	}
 	
@@ -419,7 +425,8 @@ NGI.InspectorPane = function() {
 	function onMouseUp() {
 		if (isResizing) {
 			isResizing = false;
-			document.body.classList.remove('ngi-resizing');
+			body.classList.remove('ngi-resizing');
+			setStyleProps(body, {'width': 'calc(100% - ' + pane.offsetWidth + 'px)'});
 			localStorage.setItem('ng-inspector-width', pane.offsetWidth);
 		}
 	}
@@ -427,9 +434,27 @@ NGI.InspectorPane = function() {
 	// If the user contracts the window, this makes sure the pane won't end up
 	// wider thant the viewport
 	function onResize() {
-		if (pane.offsetWidth >= document.body.offsetWidth - MINIMUM_WIDTH) {
-			pane.style.width = (document.body.offsetWidth - MINIMUM_WIDTH) + 'px';
+		if (pane.offsetWidth >= body.offsetWidth - MINIMUM_WIDTH) {
+			pane.style.width = (body.offsetWidth - MINIMUM_WIDTH) + 'px';
 		}
+	}
+
+	// Utility function to set multiple styles on an element, while ensuring 
+	// all styles set dynamically for the inspector pane have the "!important" rule enforced,
+	// to prevent collisions with the app(s) being inspected
+	function setStyleProps(element, stylesObj) {
+		Object.keys(stylesObj).forEach(function(styleProp) {
+			element.style.setProperty(styleProp, stylesObj[styleProp], 'important');
+		});
+	}
+
+	// Can perform a mapping of events/functions to addEventListener
+	// or removeEventListener, to prevent duplication when bulk adding/removing
+	function eventListenerBulk(eventsObj, remove) {
+		var eventListenerFunc = remove ? 'removeEventListener' : 'addEventListener';
+		Object.keys(eventsObj).forEach(function(event) {
+			eventsObj[event].target[eventListenerFunc](event, eventsObj[event].fn);
+		});
 	}
 
 };

--- a/ng-inspector.chrome/ng-inspector.js
+++ b/ng-inspector.chrome/ng-inspector.js
@@ -320,6 +320,7 @@ NGI.InspectorPane = function() {
 		if ( pane.parentNode ) {
 			this.visible = false;
 			document.body.removeChild(pane);
+			document.body.classList.remove('ngi-open');
 			this.clear();
 			Object.keys(events).forEach(function(key) {
 				events[key].target.removeEventListener(key, events[key].fn);
@@ -328,6 +329,7 @@ NGI.InspectorPane = function() {
 		} else {
 			this.visible = true;
 			document.body.appendChild(pane);
+			document.body.classList.add('ngi-open');
 			Object.keys(events).forEach(function(key) {
 				events[key].target.addEventListener(key, events[key].fn);
 			});

--- a/ng-inspector.chrome/ng-inspector.js
+++ b/ng-inspector.chrome/ng-inspector.js
@@ -362,6 +362,8 @@ NGI.InspectorPane = function() {
 	// are considered within the resize handle
 	var LEFT_RESIZE_HANDLE_PAD = 3;
 	var RIGHT_RESIZE_HANDLE_PAD = 2;
+	var MINIMUM_WIDTH = 50;
+	var MAXIMUM_WIDTH = 100;
 
 	// Listen for mousemove events in the page body, setting the canResize state
 	// if the mouse hovers close to the 
@@ -390,10 +392,10 @@ NGI.InspectorPane = function() {
 			var width = (window.innerWidth - event.clientX);
 
 			// Enforce minimum and maximum limits
-			if (width >= window.innerWidth - 50) {
-				width = window.innerWidth - 50;
-			} else if (width <= 100) {
-				width = 100;
+			if (width >= window.innerWidth - MINIMUM_WIDTH) {
+				width = window.innerWidth - MINIMUM_WIDTH;
+			} else if (width <= MAXIMUM_WIDTH) {
+				width = MAXIMUM_WIDTH;
 			}
 
 			pane.style.width = width + 'px';
@@ -425,8 +427,8 @@ NGI.InspectorPane = function() {
 	// If the user contracts the window, this makes sure the pane won't end up
 	// wider thant the viewport
 	function onResize() {
-		if (pane.offsetWidth >= document.body.offsetWidth - 50) {
-			pane.style.width = (document.body.offsetWidth - 50) + 'px';
+		if (pane.offsetWidth >= document.body.offsetWidth - MINIMUM_WIDTH) {
+			pane.style.width = (document.body.offsetWidth - MINIMUM_WIDTH) + 'px';
 		}
 	}
 

--- a/ng-inspector.chrome/stylesheet.css
+++ b/ng-inspector.chrome/stylesheet.css
@@ -28,9 +28,15 @@ body.ngi-resizing {
   user-select: none;
   cursor: col-resize !important;
 }
+.ngi-open {
+  margin-right: 300px !important;
+  width: calc(100% -  300px) !important;
+  overflow: scroll !important;
+}
 .ngi-inspector {
   /* Dimensions and Positioning */
   position: fixed;
+  float: right;
   top: 0;
   right: 0;
   height: 100vh;

--- a/ng-inspector.chrome/stylesheet.css
+++ b/ng-inspector.chrome/stylesheet.css
@@ -29,8 +29,6 @@ body.ngi-resizing {
   cursor: col-resize !important;
 }
 .ngi-open {
-  margin-right: 300px !important;
-  width: calc(100% -  300px) !important;
   overflow: scroll !important;
 }
 .ngi-inspector {

--- a/ng-inspector.safariextension/ng-inspector.js
+++ b/ng-inspector.safariextension/ng-inspector.js
@@ -311,22 +311,26 @@ NGI.InspectorPane = function() {
 	// Toggle the inspector pane on and off. Returns a boolean representing the
 	// new visibility state.
 	this.toggle = function() {
+		var events = {
+			mousemove: {fn: onMouseMove, target: document},
+			mousedown: {fn: onMouseDown, target: document},
+			mouseup: {fn: onMouseUp, target: document},
+			resize: {fn: onResize, target: window}
+		};
 		if ( pane.parentNode ) {
 			this.visible = false;
 			document.body.removeChild(pane);
 			this.clear();
-			document.removeEventListener('mousemove', onMouseMove);
-			document.removeEventListener('mousedown', onMouseDown);
-			document.removeEventListener('mouseup', onMouseUp);
-			window.removeEventListener('resize', onResize);
+			Object.keys(events).forEach(function(key) {
+				events[key].target.removeEventListener(key, events[key].fn);
+			});
 			return false;
 		} else {
 			this.visible = true;
 			document.body.appendChild(pane);
-			document.addEventListener('mousemove', onMouseMove);
-			document.addEventListener('mousedown', onMouseDown);
-			document.addEventListener('mouseup', onMouseUp);
-			window.addEventListener('resize', onResize);
+			Object.keys(events).forEach(function(key) {
+				events[key].target.addEventListener(key, events[key].fn);
+			});
 			return true;
 		}
 	};

--- a/ng-inspector.safariextension/ng-inspector.js
+++ b/ng-inspector.safariextension/ng-inspector.js
@@ -281,6 +281,9 @@ NGI.InspectorPane = function() {
 	// localStorage
 	var inspectorWidth = localStorage.getItem('ng-inspector-width') || 300;
 
+	// Quicker reference to body through-out InspectorPane lexical scope
+	var body = document.body;
+
 	// Create the root DOM node for the inspector pane
 	var pane = document.createElement('div');
 	pane.className = 'ngi-inspector';
@@ -317,23 +320,26 @@ NGI.InspectorPane = function() {
 			mouseup: {fn: onMouseUp, target: document},
 			resize: {fn: onResize, target: window}
 		};
+
 		if ( pane.parentNode ) {
-			this.visible = false;
-			document.body.removeChild(pane);
-			document.body.classList.remove('ngi-open');
+			body.removeChild(pane);
+			body.classList.remove('ngi-open');
+			setStyleProps(body, {
+				'width': '100%',
+				'margin-right': 0
+			});
 			this.clear();
-			Object.keys(events).forEach(function(key) {
-				events[key].target.removeEventListener(key, events[key].fn);
-			});
-			return false;
+			eventListenerBulk(events, true);
+			return this.visible = false;;
 		} else {
-			this.visible = true;
-			document.body.appendChild(pane);
-			document.body.classList.add('ngi-open');
-			Object.keys(events).forEach(function(key) {
-				events[key].target.addEventListener(key, events[key].fn);
+			body.appendChild(pane);
+			body.classList.add('ngi-open');
+			setStyleProps(body, {
+				'width': 'calc(100% - ' + pane.offsetWidth + 'px)',
+				'margin-right': pane.offsetWidth + 'px'
 			});
-			return true;
+			eventListenerBulk(events, false);
+			return this.visible = true;
 		}
 	};
 
@@ -379,10 +385,10 @@ NGI.InspectorPane = function() {
 		if (pane.offsetLeft - LEFT_RESIZE_HANDLE_PAD <= event.clientX &&
 			event.clientX <= pane.offsetLeft + RIGHT_RESIZE_HANDLE_PAD) {
 			canResize = true;
-			document.body.classList.add('ngi-resize');
+			body.classList.add('ngi-resize');
 		} else {
 			canResize = false;
-			document.body.classList.remove('ngi-resize');
+			body.classList.remove('ngi-resize');
 		}
 		
 		// If the user is currently performing a resize, the width is adjusted
@@ -409,7 +415,7 @@ NGI.InspectorPane = function() {
 	function onMouseDown() {
 		if (canResize) {
 			isResizing = true;
-			document.body.classList.add('ngi-resizing');
+			body.classList.add('ngi-resizing');
 		}
 	}
 	
@@ -419,7 +425,8 @@ NGI.InspectorPane = function() {
 	function onMouseUp() {
 		if (isResizing) {
 			isResizing = false;
-			document.body.classList.remove('ngi-resizing');
+			body.classList.remove('ngi-resizing');
+			setStyleProps(body, {'width': 'calc(100% - ' + pane.offsetWidth + 'px)'});
 			localStorage.setItem('ng-inspector-width', pane.offsetWidth);
 		}
 	}
@@ -427,9 +434,27 @@ NGI.InspectorPane = function() {
 	// If the user contracts the window, this makes sure the pane won't end up
 	// wider thant the viewport
 	function onResize() {
-		if (pane.offsetWidth >= document.body.offsetWidth - MINIMUM_WIDTH) {
-			pane.style.width = (document.body.offsetWidth - MINIMUM_WIDTH) + 'px';
+		if (pane.offsetWidth >= body.offsetWidth - MINIMUM_WIDTH) {
+			pane.style.width = (body.offsetWidth - MINIMUM_WIDTH) + 'px';
 		}
+	}
+
+	// Utility function to set multiple styles on an element, while ensuring 
+	// all styles set dynamically for the inspector pane have the "!important" rule enforced,
+	// to prevent collisions with the app(s) being inspected
+	function setStyleProps(element, stylesObj) {
+		Object.keys(stylesObj).forEach(function(styleProp) {
+			element.style.setProperty(styleProp, stylesObj[styleProp], 'important');
+		});
+	}
+
+	// Can perform a mapping of events/functions to addEventListener
+	// or removeEventListener, to prevent duplication when bulk adding/removing
+	function eventListenerBulk(eventsObj, remove) {
+		var eventListenerFunc = remove ? 'removeEventListener' : 'addEventListener';
+		Object.keys(eventsObj).forEach(function(event) {
+			eventsObj[event].target[eventListenerFunc](event, eventsObj[event].fn);
+		});
 	}
 
 };

--- a/ng-inspector.safariextension/ng-inspector.js
+++ b/ng-inspector.safariextension/ng-inspector.js
@@ -320,6 +320,7 @@ NGI.InspectorPane = function() {
 		if ( pane.parentNode ) {
 			this.visible = false;
 			document.body.removeChild(pane);
+			document.body.classList.remove('ngi-open');
 			this.clear();
 			Object.keys(events).forEach(function(key) {
 				events[key].target.removeEventListener(key, events[key].fn);
@@ -328,6 +329,7 @@ NGI.InspectorPane = function() {
 		} else {
 			this.visible = true;
 			document.body.appendChild(pane);
+			document.body.classList.add('ngi-open');
 			Object.keys(events).forEach(function(key) {
 				events[key].target.addEventListener(key, events[key].fn);
 			});

--- a/ng-inspector.safariextension/ng-inspector.js
+++ b/ng-inspector.safariextension/ng-inspector.js
@@ -362,6 +362,8 @@ NGI.InspectorPane = function() {
 	// are considered within the resize handle
 	var LEFT_RESIZE_HANDLE_PAD = 3;
 	var RIGHT_RESIZE_HANDLE_PAD = 2;
+	var MINIMUM_WIDTH = 50;
+	var MAXIMUM_WIDTH = 100;
 
 	// Listen for mousemove events in the page body, setting the canResize state
 	// if the mouse hovers close to the 
@@ -390,10 +392,10 @@ NGI.InspectorPane = function() {
 			var width = (window.innerWidth - event.clientX);
 
 			// Enforce minimum and maximum limits
-			if (width >= window.innerWidth - 50) {
-				width = window.innerWidth - 50;
-			} else if (width <= 100) {
-				width = 100;
+			if (width >= window.innerWidth - MINIMUM_WIDTH) {
+				width = window.innerWidth - MINIMUM_WIDTH;
+			} else if (width <= MAXIMUM_WIDTH) {
+				width = MAXIMUM_WIDTH;
 			}
 
 			pane.style.width = width + 'px';
@@ -425,8 +427,8 @@ NGI.InspectorPane = function() {
 	// If the user contracts the window, this makes sure the pane won't end up
 	// wider thant the viewport
 	function onResize() {
-		if (pane.offsetWidth >= document.body.offsetWidth - 50) {
-			pane.style.width = (document.body.offsetWidth - 50) + 'px';
+		if (pane.offsetWidth >= document.body.offsetWidth - MINIMUM_WIDTH) {
+			pane.style.width = (document.body.offsetWidth - MINIMUM_WIDTH) + 'px';
 		}
 	}
 

--- a/ng-inspector.safariextension/stylesheet.css
+++ b/ng-inspector.safariextension/stylesheet.css
@@ -28,9 +28,15 @@ body.ngi-resizing {
   user-select: none;
   cursor: col-resize !important;
 }
+.ngi-open {
+  margin-right: 300px !important;
+  width: calc(100% -  300px) !important;
+  overflow: scroll !important;
+}
 .ngi-inspector {
   /* Dimensions and Positioning */
   position: fixed;
+  float: right;
   top: 0;
   right: 0;
   height: 100vh;

--- a/ng-inspector.safariextension/stylesheet.css
+++ b/ng-inspector.safariextension/stylesheet.css
@@ -29,8 +29,6 @@ body.ngi-resizing {
   cursor: col-resize !important;
 }
 .ngi-open {
-  margin-right: 300px !important;
-  width: calc(100% -  300px) !important;
   overflow: scroll !important;
 }
 .ngi-inspector {

--- a/src/js/InspectorPane.js
+++ b/src/js/InspectorPane.js
@@ -53,6 +53,7 @@ NGI.InspectorPane = function() {
 		if ( pane.parentNode ) {
 			this.visible = false;
 			document.body.removeChild(pane);
+			document.body.classList.remove('ngi-open');
 			this.clear();
 			Object.keys(events).forEach(function(key) {
 				events[key].target.removeEventListener(key, events[key].fn);
@@ -61,6 +62,7 @@ NGI.InspectorPane = function() {
 		} else {
 			this.visible = true;
 			document.body.appendChild(pane);
+			document.body.classList.add('ngi-open');
 			Object.keys(events).forEach(function(key) {
 				events[key].target.addEventListener(key, events[key].fn);
 			});

--- a/src/js/InspectorPane.js
+++ b/src/js/InspectorPane.js
@@ -95,6 +95,8 @@ NGI.InspectorPane = function() {
 	// are considered within the resize handle
 	var LEFT_RESIZE_HANDLE_PAD = 3;
 	var RIGHT_RESIZE_HANDLE_PAD = 2;
+	var MINIMUM_WIDTH = 50;
+	var MAXIMUM_WIDTH = 100;
 
 	// Listen for mousemove events in the page body, setting the canResize state
 	// if the mouse hovers close to the 
@@ -123,10 +125,10 @@ NGI.InspectorPane = function() {
 			var width = (window.innerWidth - event.clientX);
 
 			// Enforce minimum and maximum limits
-			if (width >= window.innerWidth - 50) {
-				width = window.innerWidth - 50;
-			} else if (width <= 100) {
-				width = 100;
+			if (width >= window.innerWidth - MINIMUM_WIDTH) {
+				width = window.innerWidth - MINIMUM_WIDTH;
+			} else if (width <= MAXIMUM_WIDTH) {
+				width = MAXIMUM_WIDTH;
 			}
 
 			pane.style.width = width + 'px';
@@ -158,8 +160,8 @@ NGI.InspectorPane = function() {
 	// If the user contracts the window, this makes sure the pane won't end up
 	// wider thant the viewport
 	function onResize() {
-		if (pane.offsetWidth >= document.body.offsetWidth - 50) {
-			pane.style.width = (document.body.offsetWidth - 50) + 'px';
+		if (pane.offsetWidth >= document.body.offsetWidth - MINIMUM_WIDTH) {
+			pane.style.width = (document.body.offsetWidth - MINIMUM_WIDTH) + 'px';
 		}
 	}
 

--- a/src/js/InspectorPane.js
+++ b/src/js/InspectorPane.js
@@ -44,22 +44,26 @@ NGI.InspectorPane = function() {
 	// Toggle the inspector pane on and off. Returns a boolean representing the
 	// new visibility state.
 	this.toggle = function() {
+		var events = {
+			mousemove: {fn: onMouseMove, target: document},
+			mousedown: {fn: onMouseDown, target: document},
+			mouseup: {fn: onMouseUp, target: document},
+			resize: {fn: onResize, target: window}
+		};
 		if ( pane.parentNode ) {
 			this.visible = false;
 			document.body.removeChild(pane);
 			this.clear();
-			document.removeEventListener('mousemove', onMouseMove);
-			document.removeEventListener('mousedown', onMouseDown);
-			document.removeEventListener('mouseup', onMouseUp);
-			window.removeEventListener('resize', onResize);
+			Object.keys(events).forEach(function(key) {
+				events[key].target.removeEventListener(key, events[key].fn);
+			});
 			return false;
 		} else {
 			this.visible = true;
 			document.body.appendChild(pane);
-			document.addEventListener('mousemove', onMouseMove);
-			document.addEventListener('mousedown', onMouseDown);
-			document.addEventListener('mouseup', onMouseUp);
-			window.addEventListener('resize', onResize);
+			Object.keys(events).forEach(function(key) {
+				events[key].target.addEventListener(key, events[key].fn);
+			});
 			return true;
 		}
 	};

--- a/src/less/stylesheet.less
+++ b/src/less/stylesheet.less
@@ -37,9 +37,8 @@ body {
 }
 
 .ngi-open {
-	margin-right: @panel-width !important;
 	// http://stackoverflow.com/a/17904128
-	width: calc(~"100% - "@panel-width) !important;
+	//width: calc(~"100% - "@panel-width) !important;
 	overflow: scroll !important;
 }
 

--- a/src/less/stylesheet.less
+++ b/src/less/stylesheet.less
@@ -1,3 +1,5 @@
+@panel-width: 300px;
+
 /* Highlights */
 .ngi-hl {
 	padding: 0px;
@@ -34,13 +36,21 @@ body {
 	}
 }
 
+.ngi-open {
+	margin-right: @panel-width !important;
+	// http://stackoverflow.com/a/17904128
+	width: calc(~"100% - "@panel-width) !important;
+	overflow: scroll !important;
+}
+
 .ngi-inspector {
 	/* Dimensions and Positioning */
 	position: fixed;
+	float: right;
 	top: 0;
 	right: 0;
 	height: 100vh;
-	width: 300px;
+	width: @panel-width;
 	z-index: 999999999999;
 
 	/* Styling */

--- a/test/e2e/scenarios/lib/ng-inspector.js
+++ b/test/e2e/scenarios/lib/ng-inspector.js
@@ -311,22 +311,26 @@ NGI.InspectorPane = function() {
 	// Toggle the inspector pane on and off. Returns a boolean representing the
 	// new visibility state.
 	this.toggle = function() {
+		var events = {
+			mousemove: {fn: onMouseMove, target: document},
+			mousedown: {fn: onMouseDown, target: document},
+			mouseup: {fn: onMouseUp, target: document},
+			resize: {fn: onResize, target: window}
+		};
 		if ( pane.parentNode ) {
 			this.visible = false;
 			document.body.removeChild(pane);
 			this.clear();
-			document.removeEventListener('mousemove', onMouseMove);
-			document.removeEventListener('mousedown', onMouseDown);
-			document.removeEventListener('mouseup', onMouseUp);
-			window.removeEventListener('resize', onResize);
+			Object.keys(events).forEach(function(key) {
+				events[key].target.removeEventListener(key, events[key].fn);
+			});
 			return false;
 		} else {
 			this.visible = true;
 			document.body.appendChild(pane);
-			document.addEventListener('mousemove', onMouseMove);
-			document.addEventListener('mousedown', onMouseDown);
-			document.addEventListener('mouseup', onMouseUp);
-			window.addEventListener('resize', onResize);
+			Object.keys(events).forEach(function(key) {
+				events[key].target.addEventListener(key, events[key].fn);
+			});
 			return true;
 		}
 	};

--- a/test/e2e/scenarios/lib/ng-inspector.js
+++ b/test/e2e/scenarios/lib/ng-inspector.js
@@ -281,6 +281,9 @@ NGI.InspectorPane = function() {
 	// localStorage
 	var inspectorWidth = localStorage.getItem('ng-inspector-width') || 300;
 
+	// Quicker reference to body through-out InspectorPane lexical scope
+	var body = document.body;
+
 	// Create the root DOM node for the inspector pane
 	var pane = document.createElement('div');
 	pane.className = 'ngi-inspector';
@@ -317,23 +320,26 @@ NGI.InspectorPane = function() {
 			mouseup: {fn: onMouseUp, target: document},
 			resize: {fn: onResize, target: window}
 		};
+
 		if ( pane.parentNode ) {
-			this.visible = false;
-			document.body.removeChild(pane);
-			document.body.classList.remove('ngi-open');
+			body.removeChild(pane);
+			body.classList.remove('ngi-open');
+			setStyleProps(body, {
+				'width': '100%',
+				'margin-right': 0
+			});
 			this.clear();
-			Object.keys(events).forEach(function(key) {
-				events[key].target.removeEventListener(key, events[key].fn);
-			});
-			return false;
+			eventListenerBulk(events, true);
+			return this.visible = false;;
 		} else {
-			this.visible = true;
-			document.body.appendChild(pane);
-			document.body.classList.add('ngi-open');
-			Object.keys(events).forEach(function(key) {
-				events[key].target.addEventListener(key, events[key].fn);
+			body.appendChild(pane);
+			body.classList.add('ngi-open');
+			setStyleProps(body, {
+				'width': 'calc(100% - ' + pane.offsetWidth + 'px)',
+				'margin-right': pane.offsetWidth + 'px'
 			});
-			return true;
+			eventListenerBulk(events, false);
+			return this.visible = true;
 		}
 	};
 
@@ -379,10 +385,10 @@ NGI.InspectorPane = function() {
 		if (pane.offsetLeft - LEFT_RESIZE_HANDLE_PAD <= event.clientX &&
 			event.clientX <= pane.offsetLeft + RIGHT_RESIZE_HANDLE_PAD) {
 			canResize = true;
-			document.body.classList.add('ngi-resize');
+			body.classList.add('ngi-resize');
 		} else {
 			canResize = false;
-			document.body.classList.remove('ngi-resize');
+			body.classList.remove('ngi-resize');
 		}
 		
 		// If the user is currently performing a resize, the width is adjusted
@@ -409,7 +415,7 @@ NGI.InspectorPane = function() {
 	function onMouseDown() {
 		if (canResize) {
 			isResizing = true;
-			document.body.classList.add('ngi-resizing');
+			body.classList.add('ngi-resizing');
 		}
 	}
 	
@@ -419,7 +425,8 @@ NGI.InspectorPane = function() {
 	function onMouseUp() {
 		if (isResizing) {
 			isResizing = false;
-			document.body.classList.remove('ngi-resizing');
+			body.classList.remove('ngi-resizing');
+			setStyleProps(body, {'width': 'calc(100% - ' + pane.offsetWidth + 'px)'});
 			localStorage.setItem('ng-inspector-width', pane.offsetWidth);
 		}
 	}
@@ -427,9 +434,27 @@ NGI.InspectorPane = function() {
 	// If the user contracts the window, this makes sure the pane won't end up
 	// wider thant the viewport
 	function onResize() {
-		if (pane.offsetWidth >= document.body.offsetWidth - MINIMUM_WIDTH) {
-			pane.style.width = (document.body.offsetWidth - MINIMUM_WIDTH) + 'px';
+		if (pane.offsetWidth >= body.offsetWidth - MINIMUM_WIDTH) {
+			pane.style.width = (body.offsetWidth - MINIMUM_WIDTH) + 'px';
 		}
+	}
+
+	// Utility function to set multiple styles on an element, while ensuring 
+	// all styles set dynamically for the inspector pane have the "!important" rule enforced,
+	// to prevent collisions with the app(s) being inspected
+	function setStyleProps(element, stylesObj) {
+		Object.keys(stylesObj).forEach(function(styleProp) {
+			element.style.setProperty(styleProp, stylesObj[styleProp], 'important');
+		});
+	}
+
+	// Can perform a mapping of events/functions to addEventListener
+	// or removeEventListener, to prevent duplication when bulk adding/removing
+	function eventListenerBulk(eventsObj, remove) {
+		var eventListenerFunc = remove ? 'removeEventListener' : 'addEventListener';
+		Object.keys(eventsObj).forEach(function(event) {
+			eventsObj[event].target[eventListenerFunc](event, eventsObj[event].fn);
+		});
 	}
 
 };

--- a/test/e2e/scenarios/lib/ng-inspector.js
+++ b/test/e2e/scenarios/lib/ng-inspector.js
@@ -320,6 +320,7 @@ NGI.InspectorPane = function() {
 		if ( pane.parentNode ) {
 			this.visible = false;
 			document.body.removeChild(pane);
+			document.body.classList.remove('ngi-open');
 			this.clear();
 			Object.keys(events).forEach(function(key) {
 				events[key].target.removeEventListener(key, events[key].fn);
@@ -328,6 +329,7 @@ NGI.InspectorPane = function() {
 		} else {
 			this.visible = true;
 			document.body.appendChild(pane);
+			document.body.classList.add('ngi-open');
 			Object.keys(events).forEach(function(key) {
 				events[key].target.addEventListener(key, events[key].fn);
 			});

--- a/test/e2e/scenarios/lib/ng-inspector.js
+++ b/test/e2e/scenarios/lib/ng-inspector.js
@@ -362,6 +362,8 @@ NGI.InspectorPane = function() {
 	// are considered within the resize handle
 	var LEFT_RESIZE_HANDLE_PAD = 3;
 	var RIGHT_RESIZE_HANDLE_PAD = 2;
+	var MINIMUM_WIDTH = 50;
+	var MAXIMUM_WIDTH = 100;
 
 	// Listen for mousemove events in the page body, setting the canResize state
 	// if the mouse hovers close to the 
@@ -390,10 +392,10 @@ NGI.InspectorPane = function() {
 			var width = (window.innerWidth - event.clientX);
 
 			// Enforce minimum and maximum limits
-			if (width >= window.innerWidth - 50) {
-				width = window.innerWidth - 50;
-			} else if (width <= 100) {
-				width = 100;
+			if (width >= window.innerWidth - MINIMUM_WIDTH) {
+				width = window.innerWidth - MINIMUM_WIDTH;
+			} else if (width <= MAXIMUM_WIDTH) {
+				width = MAXIMUM_WIDTH;
 			}
 
 			pane.style.width = width + 'px';
@@ -425,8 +427,8 @@ NGI.InspectorPane = function() {
 	// If the user contracts the window, this makes sure the pane won't end up
 	// wider thant the viewport
 	function onResize() {
-		if (pane.offsetWidth >= document.body.offsetWidth - 50) {
-			pane.style.width = (document.body.offsetWidth - 50) + 'px';
+		if (pane.offsetWidth >= document.body.offsetWidth - MINIMUM_WIDTH) {
+			pane.style.width = (document.body.offsetWidth - MINIMUM_WIDTH) + 'px';
 		}
 	}
 

--- a/test/e2e/scenarios/lib/stylesheet.css
+++ b/test/e2e/scenarios/lib/stylesheet.css
@@ -28,9 +28,15 @@ body.ngi-resizing {
   user-select: none;
   cursor: col-resize !important;
 }
+.ngi-open {
+  margin-right: 300px !important;
+  width: calc(100% -  300px) !important;
+  overflow: scroll !important;
+}
 .ngi-inspector {
   /* Dimensions and Positioning */
   position: fixed;
+  float: right;
   top: 0;
   right: 0;
   height: 100vh;

--- a/test/e2e/scenarios/lib/stylesheet.css
+++ b/test/e2e/scenarios/lib/stylesheet.css
@@ -29,8 +29,6 @@ body.ngi-resizing {
   cursor: col-resize !important;
 }
 .ngi-open {
-  margin-right: 300px !important;
-  width: calc(100% -  300px) !important;
   overflow: scroll !important;
 }
 .ngi-inspector {

--- a/test/e2e/specs/anon.js
+++ b/test/e2e/specs/anon.js
@@ -12,7 +12,7 @@ describe('anonymous app', function() {
 
 	it('should inspect the anonymous app', function() {
 		expect($$('.ngi-app').count()).toBe(1);
-		expect($('.ngi-app > label').getText()).toBe('body.ng-scope');
+		expect($('.ngi-app > label').getText()).toBe('body.ng-scope.ngi-open');
 	});
 
 	it('should inspect the root scope', function() {


### PR DESCRIPTION
This PR modifies the styling of the inspector pane and the document body, to prevent the inspector from overlapping application content.

The E2E tests are passing (with a small change), and I've tested it on a few sites from http://builtwith.angularjs.org/. This PR doesn't cover 100% of the websites I've tested, but it does make a large majority of them a lot more usable.

Example sites that work really well with this PR:
http://www.redbeacon.com/experts/
http://gqb.ebrun.ch/#/query
http://www.virginamerica.com/
http://opentaste.co/Simon/cookies-millefeuille/

Example sites that this doesn't completely fix:
http://thiagofelix.github.io/hackynote/app/#/
http://www.constanthome.com/

This PR also doesn't make an improvement to inspecting when emulating a mobile device with Chrome dev tools.

I have not taken the time yet to test these changes within Safari. I wanted to submit the PR now so you could start reviewing/critiquing it, and I'll get to Safari verification shortly.

*Before*
![before picture](http://i.imgur.com/v4Vi0L0.png)

*After*
![after picture](http://i.imgur.com/lRjkQdh.png)