### PR TITLE
Ensure the bootstrap method exists before wrapping it.

### DIFF
--- a/ng-inspector.chrome/ng-inspector.js
+++ b/ng-inspector.chrome/ng-inspector.js
@@ -1409,7 +1409,7 @@ function bootstrap() {
 	// If angular was included via <script src=...> tag, the angular object should
 	// already be present in the window scope, and we can wrapBootstrap() right
 	// away
-	if ('angular' in window) {
+	if (window.angular && window.angular.bootstrap) {
 		wrapBootstrap();
 	} else {
 		// RequireJS and similar loaders work by injecting <script> tags into the
@@ -1423,9 +1423,9 @@ function bootstrap() {
 	// `angular.bootstrap` method
 	function wrapBootstrap() {
 
-		// Ensure that the angular object exists in the window scope and the
-		// `angular.bootstrap` method is wrapped only once
-		if (!window.angular || didWrapBootstrap) {
+		// Prevent wrapping bootstrap method if it doesn't currently exist,
+		// or if it's already been wrapped
+		if (!window.angular || window.angular && !window.angular.bootstrap || didWrapBootstrap) {
 			return;
 		}
 

--- a/ng-inspector.safariextension/ng-inspector.js
+++ b/ng-inspector.safariextension/ng-inspector.js
@@ -1409,7 +1409,7 @@ function bootstrap() {
 	// If angular was included via <script src=...> tag, the angular object should
 	// already be present in the window scope, and we can wrapBootstrap() right
 	// away
-	if ('angular' in window) {
+	if (window.angular && window.angular.bootstrap) {
 		wrapBootstrap();
 	} else {
 		// RequireJS and similar loaders work by injecting <script> tags into the
@@ -1423,9 +1423,9 @@ function bootstrap() {
 	// `angular.bootstrap` method
 	function wrapBootstrap() {
 
-		// Ensure that the angular object exists in the window scope and the
-		// `angular.bootstrap` method is wrapped only once
-		if (!window.angular || didWrapBootstrap) {
+		// Prevent wrapping bootstrap method if it doesn't currently exist,
+		// or if it's already been wrapped
+		if (!window.angular || window.angular && !window.angular.bootstrap || didWrapBootstrap) {
 			return;
 		}
 

--- a/src/js/bootstrap.js
+++ b/src/js/bootstrap.js
@@ -12,7 +12,7 @@ function bootstrap() {
 	// If angular was included via <script src=...> tag, the angular object should
 	// already be present in the window scope, and we can wrapBootstrap() right
 	// away
-	if ('angular' in window) {
+	if (window.angular && window.angular.bootstrap) {
 		wrapBootstrap();
 	} else {
 		// RequireJS and similar loaders work by injecting <script> tags into the
@@ -26,9 +26,9 @@ function bootstrap() {
 	// `angular.bootstrap` method
 	function wrapBootstrap() {
 
-		// Ensure that the angular object exists in the window scope and the
-		// `angular.bootstrap` method is wrapped only once
-		if (!window.angular || didWrapBootstrap) {
+		// Prevent wrapping bootstrap method if it doesn't currently exist,
+		// or if it's already been wrapped
+		if (!window.angular || window.angular && !window.angular.bootstrap || didWrapBootstrap) {
 			return;
 		}
 

--- a/test/e2e/scenarios/lib/ng-inspector.js
+++ b/test/e2e/scenarios/lib/ng-inspector.js
@@ -1409,7 +1409,7 @@ function bootstrap() {
 	// If angular was included via <script src=...> tag, the angular object should
 	// already be present in the window scope, and we can wrapBootstrap() right
 	// away
-	if ('angular' in window) {
+	if (window.angular && window.angular.bootstrap) {
 		wrapBootstrap();
 	} else {
 		// RequireJS and similar loaders work by injecting <script> tags into the
@@ -1423,9 +1423,9 @@ function bootstrap() {
 	// `angular.bootstrap` method
 	function wrapBootstrap() {
 
-		// Ensure that the angular object exists in the window scope and the
-		// `angular.bootstrap` method is wrapped only once
-		if (!window.angular || didWrapBootstrap) {
+		// Prevent wrapping bootstrap method if it doesn't currently exist,
+		// or if it's already been wrapped
+		if (!window.angular || window.angular && !window.angular.bootstrap || didWrapBootstrap) {
 			return;
 		}
 


### PR DESCRIPTION
Fixes issue #67, by explicitly checking for the `bootstrap` method before patching over it. I also updated an inline comment that I feel expressed the opposite of what the code below it was doing, but that's just opinion :)

