### PR TITLE
Annotate functions without $inject property, when not already annotated

### DIFF
--- a/ng-inspector.chrome/ng-inspector.js
+++ b/ng-inspector.chrome/ng-inspector.js
@@ -719,6 +719,9 @@ NGI.Service = (function() {
 		
 		switch(this.provider) {
 			case '$compileProvider':
+				if (!this.factory.$inject) {
+					this.factory.$inject = app.$injector.annotate(this.factory);
+				}
 				var dir = app.$injector.invoke(this.factory);
 				if (!dir) {
 					console.warn(

--- a/ng-inspector.safariextension/ng-inspector.js
+++ b/ng-inspector.safariextension/ng-inspector.js
@@ -719,6 +719,9 @@ NGI.Service = (function() {
 		
 		switch(this.provider) {
 			case '$compileProvider':
+				if (!this.factory.$inject) {
+					this.factory.$inject = app.$injector.annotate(this.factory);
+				}
 				var dir = app.$injector.invoke(this.factory);
 				if (!dir) {
 					console.warn(

--- a/src/js/Service.js
+++ b/src/js/Service.js
@@ -44,6 +44,9 @@ NGI.Service = (function() {
 		
 		switch(this.provider) {
 			case '$compileProvider':
+				if (!this.factory.$inject) {
+					this.factory.$inject = app.$injector.annotate(this.factory);
+				}
 				var dir = app.$injector.invoke(this.factory);
 				if (!dir) {
 					console.warn(

--- a/test/e2e/scenarios/lib/ng-inspector.js
+++ b/test/e2e/scenarios/lib/ng-inspector.js
@@ -719,6 +719,9 @@ NGI.Service = (function() {
 		
 		switch(this.provider) {
 			case '$compileProvider':
+				if (!this.factory.$inject) {
+					this.factory.$inject = app.$injector.annotate(this.factory);
+				}
 				var dir = app.$injector.invoke(this.factory);
 				if (!dir) {
 					console.warn(


### PR DESCRIPTION
Issue can be replicated with current version of `ng-inspector` here: http://plnkr.co/edit/AEnx0ZOCYiQDqtMHmY2O?p=preview.

This PR addresses #63, although unfortunately it revealed another bug on docs.angularjs.org :-1: 

