### PR TITLE
Fix bug found in latest Angular docs page

### DIFF
--- a/ng-inspector.chrome/ng-inspector.js
+++ b/ng-inspector.chrome/ng-inspector.js
@@ -734,6 +734,10 @@ NGI.Service = (function() {
 			case '$compileProvider':
 				if (!this.factory.$inject) {
 					this.factory.$inject = app.$injector.annotate(this.factory);
+					var hasInvalidDependency = this.factory.$inject.some(function(dep) {
+						return !app.$injector.has(dep);
+					});
+					if (hasInvalidDependency) return;
 				}
 				var dir = app.$injector.invoke(this.factory);
 				if (!dir) {

--- a/ng-inspector.safariextension/ng-inspector.js
+++ b/ng-inspector.safariextension/ng-inspector.js
@@ -734,6 +734,10 @@ NGI.Service = (function() {
 			case '$compileProvider':
 				if (!this.factory.$inject) {
 					this.factory.$inject = app.$injector.annotate(this.factory);
+					var hasInvalidDependency = this.factory.$inject.some(function(dep) {
+						return !app.$injector.has(dep);
+					});
+					if (hasInvalidDependency) return;
 				}
 				var dir = app.$injector.invoke(this.factory);
 				if (!dir) {

--- a/src/js/Service.js
+++ b/src/js/Service.js
@@ -46,6 +46,10 @@ NGI.Service = (function() {
 			case '$compileProvider':
 				if (!this.factory.$inject) {
 					this.factory.$inject = app.$injector.annotate(this.factory);
+					var hasInvalidDependency = this.factory.$inject.some(function(dep) {
+						return !app.$injector.has(dep);
+					});
+					if (hasInvalidDependency) return;
 				}
 				var dir = app.$injector.invoke(this.factory);
 				if (!dir) {

--- a/test/e2e/scenarios/lib/ng-inspector.js
+++ b/test/e2e/scenarios/lib/ng-inspector.js
@@ -734,6 +734,10 @@ NGI.Service = (function() {
 			case '$compileProvider':
 				if (!this.factory.$inject) {
 					this.factory.$inject = app.$injector.annotate(this.factory);
+					var hasInvalidDependency = this.factory.$inject.some(function(dep) {
+						return !app.$injector.has(dep);
+					});
+					if (hasInvalidDependency) return;
 				}
 				var dir = app.$injector.invoke(this.factory);
 				if (!dir) {


### PR DESCRIPTION
After resolving issue #63 (side-stepping strict-di), another issue was uncovered when testing on the latest Angular docs (1.4).

The issue was caused by an unused(but registered) directive on the docs page that had been minified, but not properly annotated beforehand (the same one that triggered the strict di issue, actually).

The _other_ way to fix this issue would have been to wrap the call to `invoke` in a `try/catch`. That may prevent more issues that we don't know about, but I felt it would be better to understand each issue. As of now, this is the only one I know of.

The latest Angular docs now work on this branch
