### PR TITLE
Fix Issue #91

### DIFF
--- a/ng-inspector.chrome/ng-inspector.js
+++ b/ng-inspector.chrome/ng-inspector.js
@@ -798,12 +798,10 @@ NGI.Service = (function() {
 				try {
 					var dir = app.$injector.invoke(this.factory);
 				} catch(e) {
-					console.warn(
-						'Invalid directive "' + (this.name || '(unknown)') +
-						'" found. Make sure all registered directives ' + 
-						'return a "Directive Definition Object"'
+					return console.warn(
+						'An error occurred attempting to parse directive: ' +
+						(this.name || '(unknown)')
 					);
-					return;
 				}
 				var restrict = dir.restrict || 'A';
 				var name = this.name;

--- a/ng-inspector.chrome/ng-inspector.js
+++ b/ng-inspector.chrome/ng-inspector.js
@@ -803,7 +803,7 @@ NGI.Service = (function() {
 						(this.name || '(unknown)')
 					);
 				}
-				var restrict = dir.restrict || 'A';
+				var restrict = dir.restrict || 'AE';
 				var name = this.name;
 
 				app.registerProbe(function(node, scope, isIsolate) {

--- a/ng-inspector.chrome/ng-inspector.js
+++ b/ng-inspector.chrome/ng-inspector.js
@@ -803,6 +803,8 @@ NGI.Service = (function() {
 						(this.name || '(unknown)')
 					);
 				}
+
+				if (!dir) dir = {};
 				var restrict = dir.restrict || 'AE';
 				var name = this.name;
 

--- a/ng-inspector.chrome/ng-inspector.js
+++ b/ng-inspector.chrome/ng-inspector.js
@@ -790,7 +790,7 @@ NGI.Service = (function() {
 				// Unnannotated directives declared in the application will throw an exception.
 				// If $injector.annotate is available in the user's version of Angular we
 				// attempt to salvage it, otherwise return and ignore the directive.
-				if (Object.prototype.toString.call(this.factory) !== '[object Array]') {
+				if (!Array.isArray(this.factory)) {
 					var annotation = NGI.Utils.annotate(this.factory);
 					annotation.push(this.factory);
 					this.factory = annotation;

--- a/ng-inspector.safariextension/ng-inspector.js
+++ b/ng-inspector.safariextension/ng-inspector.js
@@ -798,12 +798,10 @@ NGI.Service = (function() {
 				try {
 					var dir = app.$injector.invoke(this.factory);
 				} catch(e) {
-					console.warn(
-						'Invalid directive "' + (this.name || '(unknown)') +
-						'" found. Make sure all registered directives ' + 
-						'return a "Directive Definition Object"'
+					return console.warn(
+						'An error occurred attempting to parse directive: ' +
+						(this.name || '(unknown)')
 					);
-					return;
 				}
 				var restrict = dir.restrict || 'A';
 				var name = this.name;

--- a/ng-inspector.safariextension/ng-inspector.js
+++ b/ng-inspector.safariextension/ng-inspector.js
@@ -803,7 +803,7 @@ NGI.Service = (function() {
 						(this.name || '(unknown)')
 					);
 				}
-				var restrict = dir.restrict || 'A';
+				var restrict = dir.restrict || 'AE';
 				var name = this.name;
 
 				app.registerProbe(function(node, scope, isIsolate) {

--- a/ng-inspector.safariextension/ng-inspector.js
+++ b/ng-inspector.safariextension/ng-inspector.js
@@ -803,6 +803,8 @@ NGI.Service = (function() {
 						(this.name || '(unknown)')
 					);
 				}
+
+				if (!dir) dir = {};
 				var restrict = dir.restrict || 'AE';
 				var name = this.name;
 

--- a/ng-inspector.safariextension/ng-inspector.js
+++ b/ng-inspector.safariextension/ng-inspector.js
@@ -790,7 +790,7 @@ NGI.Service = (function() {
 				// Unnannotated directives declared in the application will throw an exception.
 				// If $injector.annotate is available in the user's version of Angular we
 				// attempt to salvage it, otherwise return and ignore the directive.
-				if (Object.prototype.toString.call(this.factory) !== '[object Array]') {
+				if (!Array.isArray(this.factory)) {
 					var annotation = NGI.Utils.annotate(this.factory);
 					annotation.push(this.factory);
 					this.factory = annotation;

--- a/src/js/Service.js
+++ b/src/js/Service.js
@@ -27,12 +27,10 @@ NGI.Service = (function() {
 				try {
 					var dir = app.$injector.invoke(this.factory);
 				} catch(e) {
-					console.warn(
-						'Invalid directive "' + (this.name || '(unknown)') +
-						'" found. Make sure all registered directives ' + 
-						'return a "Directive Definition Object"'
+					return console.warn(
+						'An error occurred attempting to parse directive: ' +
+						(this.name || '(unknown)')
 					);
-					return;
 				}
 				var restrict = dir.restrict || 'A';
 				var name = this.name;

--- a/src/js/Service.js
+++ b/src/js/Service.js
@@ -32,6 +32,8 @@ NGI.Service = (function() {
 						(this.name || '(unknown)')
 					);
 				}
+
+				if (!dir) dir = {};
 				var restrict = dir.restrict || 'AE';
 				var name = this.name;
 

--- a/src/js/Service.js
+++ b/src/js/Service.js
@@ -19,7 +19,7 @@ NGI.Service = (function() {
 				// Unnannotated directives declared in the application will throw an exception.
 				// If $injector.annotate is available in the user's version of Angular we
 				// attempt to salvage it, otherwise return and ignore the directive.
-				if (Object.prototype.toString.call(this.factory) !== '[object Array]') {
+				if (!Array.isArray(this.factory)) {
 					var annotation = NGI.Utils.annotate(this.factory);
 					annotation.push(this.factory);
 					this.factory = annotation;

--- a/src/js/Service.js
+++ b/src/js/Service.js
@@ -32,7 +32,7 @@ NGI.Service = (function() {
 						(this.name || '(unknown)')
 					);
 				}
-				var restrict = dir.restrict || 'A';
+				var restrict = dir.restrict || 'AE';
 				var name = this.name;
 
 				app.registerProbe(function(node, scope, isIsolate) {

--- a/test/e2e/scenarios/empty-directive.html
+++ b/test/e2e/scenarios/empty-directive.html
@@ -7,10 +7,6 @@
 	<script src="lib/ng-inspector.js"></script>
 	<style>@import url(lib/stylesheet.css);</style>
 	<script>
-
-		console.warn = function(msg) {
-			document.getElementById('warning').innerHTML = msg;
-		}
 			
 		var app = angular.module('MyApp', []);
 
@@ -27,8 +23,6 @@
 <body ng-app="MyApp">
 
 	<p ng-controller="MainCtrl">Hello {{name}}!</p>
-
-	<p id="warning"></p>
 
 	<button type="button" onclick="window.ngInspector.toggle()" id="ngInspectorToggle">ngInspector</button>
 

--- a/test/e2e/scenarios/lib/ng-inspector.js
+++ b/test/e2e/scenarios/lib/ng-inspector.js
@@ -798,12 +798,10 @@ NGI.Service = (function() {
 				try {
 					var dir = app.$injector.invoke(this.factory);
 				} catch(e) {
-					console.warn(
-						'Invalid directive "' + (this.name || '(unknown)') +
-						'" found. Make sure all registered directives ' + 
-						'return a "Directive Definition Object"'
+					return console.warn(
+						'An error occurred attempting to parse directive: ' +
+						(this.name || '(unknown)')
 					);
-					return;
 				}
 				var restrict = dir.restrict || 'A';
 				var name = this.name;

--- a/test/e2e/scenarios/lib/ng-inspector.js
+++ b/test/e2e/scenarios/lib/ng-inspector.js
@@ -803,7 +803,7 @@ NGI.Service = (function() {
 						(this.name || '(unknown)')
 					);
 				}
-				var restrict = dir.restrict || 'A';
+				var restrict = dir.restrict || 'AE';
 				var name = this.name;
 
 				app.registerProbe(function(node, scope, isIsolate) {

--- a/test/e2e/scenarios/lib/ng-inspector.js
+++ b/test/e2e/scenarios/lib/ng-inspector.js
@@ -803,6 +803,8 @@ NGI.Service = (function() {
 						(this.name || '(unknown)')
 					);
 				}
+
+				if (!dir) dir = {};
 				var restrict = dir.restrict || 'AE';
 				var name = this.name;
 

--- a/test/e2e/scenarios/lib/ng-inspector.js
+++ b/test/e2e/scenarios/lib/ng-inspector.js
@@ -790,7 +790,7 @@ NGI.Service = (function() {
 				// Unnannotated directives declared in the application will throw an exception.
 				// If $injector.annotate is available in the user's version of Angular we
 				// attempt to salvage it, otherwise return and ignore the directive.
-				if (Object.prototype.toString.call(this.factory) !== '[object Array]') {
+				if (!Array.isArray(this.factory)) {
 					var annotation = NGI.Utils.annotate(this.factory);
 					annotation.push(this.factory);
 					this.factory = annotation;

--- a/test/e2e/specs/empty-directive.js
+++ b/test/e2e/specs/empty-directive.js
@@ -12,9 +12,15 @@ describe('empty directive', function() {
 		browser.sleep(250);
   });
 
-	it('should warn about empty directive declarations', function() {
-		expect($('#warning').getText())
-			.toMatch(/Make sure all registered directives return a "Directive Definition Object"/);
+	it('should not throw exception when directive with DDO is used', function() {
+		browser.manage().logs().get('browser').then(function (browserLog) {
+			var severeWarnings = browserLog.filter(function(log) {
+				// Not concerned about info or warnings
+				return log.level.name === 'SEVERE';
+			});
+
+			expect(severeWarnings.length).toBe(0);
+		});
 	});
 
 });


### PR DESCRIPTION
Changed made:

1. (Stylistic) I changed the array check to `Array.isArray`. I personally feel it's slightly more descriptive of it's intent. Let me know if you have any problems with it and I'll pull it out.

2. Made exception message generic (since we don't know of any use-case currently that will cause the `invoke` to throw).

3. If `invoke` returns undefined, default to an empty object, to allow the rest of the "process" to continue without issue. I considered returning right here, but I'm not familiar enough with the code below. It *looks* like it would be safe to return early, but I'd like your input.

4.  Changed the default `restrict` property to `AE`, since Angular's docs mention that is the default. This is a wild guess, but I'm thinking that may be part of the issue causing #92.

5. Removed (now) superfluous code in the `empty directive` test, and updated the test to check for an exception, rather than our `console.warn` (since we're no longer warning users in this scenario, for now).