### PR TITLE
Added default color for label

### DIFF
--- a/src/less/stylesheet.less
+++ b/src/less/stylesheet.less
@@ -185,6 +185,7 @@ body:not(.ngi-resizing) .ngi-inspector .ngi-scope.ngi-isolate-scope>label:hover 
 	padding: 0 5px 0 24px;
 	background: #fff url(icons/model.png) no-repeat 4px 7px;
 	position: relative;
+	color: black !important;
 }
 .ngi-inspector .ngi-model > label .ngi-value {
 	font-weight: normal !important;


### PR DESCRIPTION
I have white colour set as default on my website, that's why I can't see properties before :hover event binded.
Screenshot before:
![before](http://i.imgur.com/jTgsK5s.png)

After changes:
![after](http://i.imgur.com/kpliJ09.png)