### PR TITLE
Upgrade Protractor to 2.0

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,6 +20,15 @@ JavaScript source is located at `/src`, and uses [gulp](http://gulpjs.com) to bu
 
 ## Testing
 
-ng-inspector uses [Protractor](https://github.com/angular/protractor) for end to end tests in Chrome. First, execute `npm run update-webdriver` to let Protractor download or update the required Chrome webdriver. Then start the scenarios server with `npm run scenarios` and finally `npm test` to run the tests.
+ng-inspector uses [Protractor](https://github.com/angular/protractor) for end to end tests in Chrome. 
 
-Scenarios are small angular applications written to test various AngularJS use cases, and are located at `/test/e2e/scenarios/`. Each scenario should have one spec file containing the tests themselves, and they are located at `/test/e2e/specs/`.
+### Running Tests
+
+1. Run `gulp` to ensure you have a fresh copy of the extension built from source
+2. Run `npm run update-webdriver` to download/update the Chrome webdriver
+3. Run `npm run start-webdriver` to start the local webdriver server
+4. Run `npm run scenarios` to start a local webserver that serves the Scenarios*
+5. Run `npm test` to execute the test suite
+
+
+*Scenarios are small angular applications written to test various AngularJS use cases, and are located at `/test/e2e/scenarios/`. Each scenario should have one spec file containing the tests themselves, and they are located at `/test/e2e/specs/`.

--- a/package.json
+++ b/package.json
@@ -27,17 +27,17 @@
   },
   "homepage": "https://github.com/rev087/ng-inspector",
   "devDependencies": {
+    "colors": "~0.6.2",
     "gulp": "~3.6.2",
     "gulp-concat": "~2.2.0",
-    "gulp-wrap": "~0.3.0",
-    "semver": "~2.3.0",
-    "colors": "~0.6.2",
-    "plist": "~0.4.3",
     "gulp-jshint": "~1.5.5",
     "gulp-less": "~1.2.3",
     "gulp-replace": "~0.3.0",
-    "protractor": "~0.24.0",
+    "gulp-wrap": "~0.3.0",
     "http-server": "~0.6.1",
-    "jpm": "^1.0.0"
+    "jpm": "^1.0.0",
+    "plist": "~0.4.3",
+    "protractor": "^2.0.0",
+    "semver": "~2.3.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "test": "./node_modules/.bin/protractor test/protractor.conf.js",
     "update-webdriver": "./node_modules/.bin/webdriver-manager update",
+    "start-webdriver": "./node_modules/.bin/webdriver-manager start",
     "scenarios": "./node_modules/.bin/http-server test/e2e/scenarios/ -p 8000",
     "build-xpi": "gulp && cd ng-inspector.firefox && jpm xpi ",
     "run-xpi": "gulp && cd ng-inspector.firefox && jpm run "

--- a/test/e2e/specs/anon.js
+++ b/test/e2e/specs/anon.js
@@ -1,14 +1,9 @@
-browser.ignoreSynchronization = true;
-var $$ = function(query) { return element.all(by.css(query)); }
-var $ = function(query) { return element(by.css(query)); }
-
 describe('anonymous app', function() {
 
-  beforeEach(function () {
+	beforeEach(function () {
 		browser.get('/anon.html');
 		element(by.id('ngInspectorToggle')).click();
-		browser.sleep(250);
-  });
+	});
 
 	it('should inspect the anonymous app', function() {
 		expect($$('.ngi-app').count()).toBe(1);

--- a/test/e2e/specs/bootstrap-jquery.js
+++ b/test/e2e/specs/bootstrap-jquery.js
@@ -1,14 +1,9 @@
-browser.ignoreSynchronization = true;
-var $$ = function(query) { return element.all(by.css(query)); }
-var $ = function(query) { return element(by.css(query)); }
-
 describe('bootstrap with a jquery object', function() {
 
-  beforeEach(function () {
+	beforeEach(function () {
 		browser.get('/bootstrap-jquery.html');
 		element(by.id('ngInspectorToggle')).click();
-		browser.sleep(250);
-  });
+	});
 
 	it('should inspect the directive in a dependency', function() {
 		expect($('.ngi-inspector .ngi-value').getText()).toBe('"John Doe"');

--- a/test/e2e/specs/circular-reference.js
+++ b/test/e2e/specs/circular-reference.js
@@ -1,13 +1,8 @@
-browser.ignoreSynchronization = true;
-var $$ = function(query) { return element.all(by.css(query)); }
-var $ = function(query) { return element(by.css(query)); }
-
 describe('detect circular references', function() {
 
 	beforeEach(function () {
 		browser.get('/circular-reference.html');
 		element(by.id('ngInspectorToggle')).click();
-		browser.sleep(250);
 	});
 
 	it('should detect a circular reference', function() {

--- a/test/e2e/specs/collapse-expand.js
+++ b/test/e2e/specs/collapse-expand.js
@@ -29,7 +29,6 @@ function $p() { return $(path.apply(null, arguments)); }
 describe('collapse and expand treeview items', function() {
 
 	beforeEach(function () {
-		browser.ignoreSynchronization = false;
 		browser.get('/collapse-expand.html');
 		element(by.id('ngInspectorToggle')).click();
 	});

--- a/test/e2e/specs/collapse-expand.js
+++ b/test/e2e/specs/collapse-expand.js
@@ -1,7 +1,3 @@
-browser.ignoreSynchronization = true;
-var $$ = function(query) { return element.all(by.css(query)); }
-var $ = function(query) { return element(by.css(query)); }
-
 /**
  * Receives N CSS class names as arguments, and returns a selector in the
  * format:
@@ -27,15 +23,15 @@ function toggle() {
 	sel += ' > label > .ngi-caret';
 	element(by.css(sel)).click();
 }
+
 function $p() { return $(path.apply(null, arguments)); }
-function $$p() { return $$(path.apply(null, arguments)); }
 
 describe('collapse and expand treeview items', function() {
 
 	beforeEach(function () {
+		browser.ignoreSynchronization = false;
 		browser.get('/collapse-expand.html');
 		element(by.id('ngInspectorToggle')).click();
-		browser.sleep(250);
 	});
 
 	it('should expand and collapse object models', function() {

--- a/test/e2e/specs/dependency.js
+++ b/test/e2e/specs/dependency.js
@@ -1,14 +1,9 @@
-browser.ignoreSynchronization = true;
-var $$ = function(query) { return element.all(by.css(query)); }
-var $ = function(query) { return element(by.css(query)); }
-
 describe('dependency', function() {
 
-  beforeEach(function () {
+	beforeEach(function () {
 		browser.get('/dependency.html');
 		element(by.id('ngInspectorToggle')).click();
-		browser.sleep(250);
-  });
+	});
 
 	it('should inspect the directive in a dependency', function() {
 		expect($$('.ngi-scope').count()).toBe(2);

--- a/test/e2e/specs/directive-object-declaration.js
+++ b/test/e2e/specs/directive-object-declaration.js
@@ -1,7 +1,3 @@
-browser.ignoreSynchronization = true;
-var $$ = function(query) { return element.all(by.css(query)); }
-var $ = function(query) { return element(by.css(query)); }
-
 /**
  * Receives N CSS class names as arguments, and returns a selector in the
  * format:
@@ -33,7 +29,6 @@ describe('identify directives declared with the object style', function() {
 	beforeEach(function () {
 		browser.get('/directive-object-declaration.html');
 		element(by.id('ngInspectorToggle')).click();
-		browser.sleep(250);
 	});
 
 	it('should expand and collapse object models', function() {

--- a/test/e2e/specs/empty-directive.js
+++ b/test/e2e/specs/empty-directive.js
@@ -1,16 +1,11 @@
-browser.ignoreSynchronization = true;
-var $$ = function(query) { return element.all(by.css(query)); }
-var $ = function(query) { return element(by.css(query)); }
-
 describe('empty directive', function() {
 
 	var _warn, _warnMessage;
 
-  beforeEach(function () {
+	beforeEach(function () {
 		browser.get('/empty-directive.html');
 		element(by.id('ngInspectorToggle')).click();
-		browser.sleep(250);
-  });
+	});
 
 	it('should not throw exception when directive with DDO is used', function() {
 		browser.manage().logs().get('browser').then(function (browserLog) {

--- a/test/e2e/specs/empty-directive.js
+++ b/test/e2e/specs/empty-directive.js
@@ -7,14 +7,17 @@ describe('empty directive', function() {
 		element(by.id('ngInspectorToggle')).click();
 	});
 
-	it('should not throw exception when directive with DDO is used', function() {
+	it('should not throw exception when directive with empty DDO is used', function() {
 		browser.manage().logs().get('browser').then(function (browserLog) {
 			var severeWarnings = browserLog.filter(function(log) {
 				// Not concerned about info or warnings
 				return log.level.name === 'SEVERE';
 			});
 
-			expect(severeWarnings.length).toBe(0);
+			severeWarnings.forEach(function(warning) {
+				// https://github.com/rev087/ng-inspector/issues/39
+				expect(warning.message).toNotMatch(/Cannot read property 'restrict' of undefined/i);
+			});
 		});
 	});
 

--- a/test/e2e/specs/requirejs.js
+++ b/test/e2e/specs/requirejs.js
@@ -1,15 +1,9 @@
-browser.ignoreSynchronization = true;
-var $$ = function(query) { return element.all(by.css(query)); }
-var $ = function(query) { return element(by.css(query)); }
-
 describe('require.js', function() {
 
-  beforeEach(function () {
+	beforeEach(function () {
 		browser.get('/requirejs.html');
-		browser.sleep(250);
 		element(by.id('ngInspectorToggle')).click();
-		browser.sleep(250);
-  });
+	});
 
 	it('should inspect app loaded with require.js', function() {
 		expect($('.ngi-app > label').getText()).toBe('document');

--- a/test/e2e/specs/strict-di.js
+++ b/test/e2e/specs/strict-di.js
@@ -1,14 +1,9 @@
-browser.ignoreSynchronization = true;
-var $$ = function(query) { return element.all(by.css(query)); }
-var $ = function(query) { return element(by.css(query)); }
-
 describe('strict di', function() {
 
-  beforeEach(function () {
+	beforeEach(function () {
 		browser.get('/strict-di.html');
 		element(by.id('ngInspectorToggle')).click();
-		browser.sleep(250);
-  });
+	});
 
 	it('should not throw an error when unannotated directive is used', function() {
 		browser.manage().logs().get('browser').then(function (browserLog) {
@@ -18,7 +13,7 @@ describe('strict di', function() {
 
 			if (!severeWarnings.length) return;
 
-			severeWarnings.map(function(log) {
+			severeWarnings.forEach(function(log) {
 				expect(log.message).toNotMatch(/strictdi/);
 			});
 		});

--- a/test/protractor.conf.js
+++ b/test/protractor.conf.js
@@ -1,8 +1,6 @@
 // Docs for protractor 0.24:
 // https://github.com/angular/protractor/blob/8582b195ed0f4d48a0d9513017b21e99f8feb2fe/docs/api.md
 exports.config = {
-  sauceUser: process.env.SAUCE_USERNAME,
-  sauceKey: process.env.SAUCE_ACCESS_KEY,
   allScriptsTimeout: 11000,
 
   specs: [
@@ -13,11 +11,7 @@ exports.config = {
     'browserName': 'chrome'
   },
 
-  chromeOnly: true,
-
   baseUrl: 'http://localhost:8000/',
-
-  framework: 'jasmine',
 
   jasmineNodeOpts: {
     showColors: true,


### PR DESCRIPTION
Changed made in this PR:

1. Upgraded Protractor to 2.0
2. Removed `browser.ignoreSynchronization = true` calls that were making it necessary for us to call `browser.sleep`
3. Removed `$` and `$$` util functions, since they're now exposed by Protractor
4. Fixed inconsistent indentation of `beforeEach` blocks
5. Removed superfluous settings from `protractor.conf.js`
6. Fixed my horrible test in `empty-directive.js` to be more explicit
7. Updated `CONTRIBUTING.md` with new test steps

This PR *should* close issues #98 & #101.