### PR TITLE
Browserify

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,7 @@
+{
+	"strict": false,
+	"expr": true,
+	"boss": true,
+	"shadow": true,
+	"predef": ["console"]
+}

--- a/gulp/config.js
+++ b/gulp/config.js
@@ -9,6 +9,8 @@ module.exports = {
 	chromeDir: 'ng-inspector.chrome',
 	iconsDir: 'src/icons',
 	jsDir: 'src/js',
+	browserifyEntry: 'src/js/bootstrap.js',
+	jsOutputName: 'ng-inspector.js',
 	testDir: testDir,
 	e2eDir: format('%s/e2e', testDir)
 };

--- a/gulp/tasks/build-js.js
+++ b/gulp/tasks/build-js.js
@@ -1,15 +1,23 @@
+var browserify = require('browserify');
 var gulp = require('gulp');
-var concat = require('gulp-concat');
-var wrap = require('gulp-wrap');
-var config = require('../config');
+var source = require('vinyl-source-stream');
+var buffer = require('vinyl-buffer');
+var gutil = require('gulp-util');
 var format = require('util').format;
+var config = require('../config');
 
-gulp.task('build:js', function() {
-	return gulp.src([format('%s/*.js', config.jsDir)])
-		.pipe(concat('ng-inspector.js', {newLine:"\n\n"}))
-		.pipe(wrap("(function(window) {\n\"use strict\";\n\n<%= contents %>\n})(window);"), {variable:'data'})
-		.pipe(gulp.dest(format('%s/', config.safariDir)))
-		.pipe(gulp.dest(format('%s/', config.chromeDir)))
-		.pipe(gulp.dest(format('%s/data/', config.firefoxDir)))
-		.pipe(gulp.dest(format('%s/scenarios/lib/', config.e2eDir)));
+gulp.task('build:js', function () {
+  var b = browserify({
+    entries: config.browserifyEntry,
+    debug: true
+  });
+
+  return b.bundle()
+    .pipe(source(config.jsOutputName))
+    .pipe(buffer())
+    .on('error', gutil.log)
+    .pipe(gulp.dest(format('%s/', config.safariDir)))
+    .pipe(gulp.dest(format('%s/', config.chromeDir)))
+    .pipe(gulp.dest(format('%s/data/', config.firefoxDir)))
+    .pipe(gulp.dest(format('%s/scenarios/lib/', config.e2eDir)));
 });

--- a/package.json
+++ b/package.json
@@ -33,12 +33,16 @@
     "gulp-jshint": "~1.5.5",
     "gulp-less": "~1.2.3",
     "gulp-replace": "~0.3.0",
+    "gulp-uglify": "^1.2.0",
+    "gulp-util": "^3.0.5",
     "gulp-webserver": "^0.9.0",
     "gulp-wrap": "~0.3.0",
     "jpm": "^1.0.0",
     "plist": "~0.4.3",
     "protractor": "^2.0.0",
     "require-dir": "^0.3.0",
-    "semver": "~2.3.0"
+    "semver": "~2.3.0",
+    "vinyl-buffer": "^1.0.0",
+    "vinyl-source-stream": "^1.1.0"
   }
 }

--- a/src/js/App.js
+++ b/src/js/App.js
@@ -1,197 +1,196 @@
-/* global NGI */
-/* jshint strict: false */
-/* jshint expr: true */
+var NGI = {
+	InspectorAgent: require('./InspectorAgent'),
+	Module: require('./Module'),
+	TreeView: require('./TreeView'),
+	Service: require('./Service')
+};
 
-NGI.App = (function(window) {
+function App(node, modules) {
+	var pane = window.ngInspector.pane;
+	var app = this;
+	var observer = new MutationObserver(function(mutations) {
+		setTimeout(function() {
+			for (var i = 0; i < mutations.length; i++) {
+				var target = mutations[i].target;
 
-	function App(node, modules) {
-		var pane = window.ngInspector.pane;
-		var app = this;
-		var observer = new MutationObserver(function(mutations) {
-			setTimeout(function() {
-				for (var i = 0; i < mutations.length; i++) {
-					var target = mutations[i].target;
-
-					// Avoid responding to mutations in the extension UI
-					if (!pane.contains(target)) {
-						for (var f = 0; f < mutations[i].addedNodes.length; f++) {
-							var addedNode = mutations[i].addedNodes[f];
-							if (addedNode.classList && !addedNode.classList.contains('ngi-hl')) {
-								NGI.InspectorAgent.inspectNode(app, addedNode);
-							}
+				// Avoid responding to mutations in the extension UI
+				if (!pane.contains(target)) {
+					for (var f = 0; f < mutations[i].addedNodes.length; f++) {
+						var addedNode = mutations[i].addedNodes[f];
+						if (addedNode.classList && !addedNode.classList.contains('ngi-hl')) {
+							NGI.InspectorAgent.inspectNode(app, addedNode);
 						}
 					}
 				}
-			}, 4);
-		});
-		var observerConfig = { childList: true, subtree: true };
-
-		this.startObserver = function() {
-			observer.observe(node, observerConfig);
-		};
-
-		this.stopObserver = function() {
-			observer.disconnect();
-		};
-
-		this.node = node;
-
-		this.$injector = window.angular.element(node).data('$injector');
-		
-		if (!modules) {
-			modules = [];
-		} else if (typeof modules === typeof '') {
-			modules = [modules];
-		}
-
-		var probes = [builtInProbe];
-		this.registerProbe = function(probe) {
-			probes.push(probe);
-		};
-
-		this.probe = function(node, scope, isIsolate) {
-			for (var i = 0; i < probes.length; i++) {
-				probes[i](node, scope, isIsolate);
 			}
-		};
+		}, 4);
+	});
+	var observerConfig = { childList: true, subtree: true };
 
-		// Attempt to retrieve the property of the ngApp directive in the node from
-		// one of the possible declarations to retrieve the AngularJS module defined
-		// as the main dependency for the app. An anonymous ngApp is a valid use
-		// case, so this is optional.
-		var attrs = ['ng\\:app', 'ng-app', 'x-ng-app', 'data-ng-app'];
-		var main;
-		if ('getAttribute' in node) {
-			for (var i = 0; i < attrs.length; i++) {
-				if (node.hasAttribute(attrs[i])) {
-					main = node.getAttribute(attrs[i]);
-					break;
-				}
-			}
-			if (main) {
-				modules.push(main);
-			}
-		}
+	this.startObserver = function() {
+		observer.observe(node, observerConfig);
+	};
 
-		// Register module dependencies
-		for (var m = 0; m < modules.length; m++) {
-			NGI.Module.register(this, modules[m]);
-		}
+	this.stopObserver = function() {
+		observer.disconnect();
+	};
 
-		var label = main ? main : nodeRep(node);
-		this.view = NGI.TreeView.appItem(label, node);
-		window.ngInspector.pane.treeView.appendChild(this.view.element);
+	this.node = node;
+
+	this.$injector = window.angular.element(node).data('$injector');
+	
+	if (!modules) {
+		modules = [];
+	} else if (typeof modules === typeof '') {
+		modules = [modules];
 	}
 
-	// This probe is registered by default in all apps, and probes nodes
-	// for AngularJS built-in directives that are not exposed in the _invokeQueue
-	// despite the 'ng' module being a default dependency
-	function builtInProbe(node, scope) {
+	var probes = [builtInProbe];
+	this.registerProbe = function(probe) {
+		probes.push(probe);
+	};
 
-		if (node === document) {
-			node = document.getElementsByTagName('html')[0];
+	this.probe = function(node, scope, isIsolate) {
+		for (var i = 0; i < probes.length; i++) {
+			probes[i](node, scope, isIsolate);
 		}
+	};
 
-		if (node && node.hasAttribute('ng-repeat')) {
-			scope.view.addAnnotation('ngRepeat', NGI.Service.BUILTIN);
+	// Attempt to retrieve the property of the ngApp directive in the node from
+	// one of the possible declarations to retrieve the AngularJS module defined
+	// as the main dependency for the app. An anonymous ngApp is a valid use
+	// case, so this is optional.
+	var attrs = ['ng\\:app', 'ng-app', 'x-ng-app', 'data-ng-app'];
+	var main;
+	if ('getAttribute' in node) {
+		for (var i = 0; i < attrs.length; i++) {
+			if (node.hasAttribute(attrs[i])) {
+				main = node.getAttribute(attrs[i]);
+				break;
+			}
 		}
-
-		// Label ng-include scopes
-		if (node && node.hasAttribute('ng-include')) {
-			scope.view.addAnnotation('ngInclude', NGI.Service.BUILTIN);
-		}
-
-		// Label ng-if scopes
-		if (node && node.hasAttribute('ng-if')) {
-			scope.view.addAnnotation('ngIf', NGI.Service.BUILTIN);
-		}
-
-		// Label root scopes
-		if (scope.ngScope.$root.$id === scope.ngScope.$id) {
-			scope.view.addAnnotation('$rootScope', NGI.Service.BUILTIN);
-		}
-
-		// Label ng-transclude scopes
-		if (node && node.parentNode && node.parentNode.hasAttribute &&
-			node.parentNode.hasAttribute('ng-transclude')) {
-			scope.view.addAnnotation('ngTransclude', NGI.Service.BUILTIN);
+		if (main) {
+			modules.push(main);
 		}
 	}
 
-	var appCache = [];
-	App.bootstrap = function(node, modules) {
-		for (var i = 0; i < appCache.length; i++) {
-			if (appCache[i].node === node) {
-				return appCache[i];
-			}
+	// Register module dependencies
+	for (var m = 0; m < modules.length; m++) {
+		NGI.Module.register(this, modules[m]);
+	}
+
+	var label = main ? main : nodeRep(node);
+	this.view = NGI.TreeView.appItem(label, node);
+	window.ngInspector.pane.treeView.appendChild(this.view.element);
+}
+
+// This probe is registered by default in all apps, and probes nodes
+// for AngularJS built-in directives that are not exposed in the _invokeQueue
+// despite the 'ng' module being a default dependency
+function builtInProbe(node, scope) {
+
+	if (node === document) {
+		node = document.getElementsByTagName('html')[0];
+	}
+
+	if (node && node.hasAttribute('ng-repeat')) {
+		scope.view.addAnnotation('ngRepeat', NGI.Service.BUILTIN);
+	}
+
+	// Label ng-include scopes
+	if (node && node.hasAttribute('ng-include')) {
+		scope.view.addAnnotation('ngInclude', NGI.Service.BUILTIN);
+	}
+
+	// Label ng-if scopes
+	if (node && node.hasAttribute('ng-if')) {
+		scope.view.addAnnotation('ngIf', NGI.Service.BUILTIN);
+	}
+
+	// Label root scopes
+	if (scope.ngScope.$root.$id === scope.ngScope.$id) {
+		scope.view.addAnnotation('$rootScope', NGI.Service.BUILTIN);
+	}
+
+	// Label ng-transclude scopes
+	if (node && node.parentNode && node.parentNode.hasAttribute &&
+		node.parentNode.hasAttribute('ng-transclude')) {
+		scope.view.addAnnotation('ngTransclude', NGI.Service.BUILTIN);
+	}
+}
+
+var appCache = [];
+App.bootstrap = function(node, modules) {
+	for (var i = 0; i < appCache.length; i++) {
+		if (appCache[i].node === node) {
+			return appCache[i];
 		}
-		var newApp = new App(node, modules);
-		if (window.ngInspector.pane.visible) {
-			NGI.InspectorAgent.inspectApp(newApp);
-			newApp.startObserver();
-		}
-		appCache.push(newApp);
-	};
+	}
+	var newApp = new App(node, modules);
+	if (window.ngInspector.pane.visible) {
+		NGI.InspectorAgent.inspectApp(newApp);
+		newApp.startObserver();
+	}
+	appCache.push(newApp);
+};
 
-	var didFindApps = false;
+var didFindApps = false;
 
-	App.inspectApps = function() {
-		if (!didFindApps) {
-			NGI.InspectorAgent.findApps();
-			didFindApps = true;
-		}
+App.inspectApps = function() {
+	if (!didFindApps) {
+		NGI.InspectorAgent.findApps(App);
+		didFindApps = true;
+	}
 
-		for (var i = 0; i < appCache.length; i++) {
-			NGI.InspectorAgent.inspectApp(appCache[i]);
-			appCache[i].startObserver();
-		}
-	};
+	for (var i = 0; i < appCache.length; i++) {
+		NGI.InspectorAgent.inspectApp(appCache[i]);
+		appCache[i].startObserver();
+	}
+};
 
-	App.startObservers = function() {
-		for (var i = 0; i < appCache.length; i++) {
-			appCache[i].startObserver();
-		}
+App.startObservers = function() {
+	for (var i = 0; i < appCache.length; i++) {
+		appCache[i].startObserver();
+	}
 
-	};
+};
 
-	App.stopObservers = function() {
-		for (var i = 0; i < appCache.length; i++) {
-			appCache[i].stopObserver();
-		}
-	};
+App.stopObservers = function() {
+	for (var i = 0; i < appCache.length; i++) {
+		appCache[i].stopObserver();
+	}
+};
 
-	// Utility function that returns a DOM Node to be injected in the UI,
-	// displaying a user-friendly CSS selector-like representation of a DOM Node
-	// in the inspected application
-	function nodeRep(node) {
-		var label = document.createElement('label');
+// Utility function that returns a DOM Node to be injected in the UI,
+// displaying a user-friendly CSS selector-like representation of a DOM Node
+// in the inspected application
+function nodeRep(node) {
+	var label = document.createElement('label');
 
-		if (node === document) {
-			label.textContent = 'document';
-			return label;
-		}
-
-		// tag
-		label.textContent = node.tagName.toLowerCase();
-
-		// #id
-		if (node.hasAttribute('id')) {
-			var small = document.createElement('small');
-			small.textContent = '#' + node.getAttribute('id');
-			label.appendChild(small);
-		}
-
-		// .class.list
-		var classList = node.className.split(/\s/);
-		for (var i = 0; i < classList.length; i++) {
-			var small = document.createElement('small');
-			small.textContent = '.' + classList[i];
-			label.appendChild(small);
-		}
-
+	if (node === document) {
+		label.textContent = 'document';
 		return label;
 	}
 
-	return App;
+	// tag
+	label.textContent = node.tagName.toLowerCase();
 
-})(window);
+	// #id
+	if (node.hasAttribute('id')) {
+		var small = document.createElement('small');
+		small.textContent = '#' + node.getAttribute('id');
+		label.appendChild(small);
+	}
+
+	// .class.list
+	var classList = node.className.split(/\s/);
+	for (var i = 0; i < classList.length; i++) {
+		var small = document.createElement('small');
+		small.textContent = '.' + classList[i];
+		label.appendChild(small);
+	}
+
+	return label;
+}
+
+module.exports = App;

--- a/src/js/Highlighter.js
+++ b/src/js/Highlighter.js
@@ -1,50 +1,41 @@
-/* global NGI */
-/* jshint strict: false */
-/* jshint expr: true */
-/* jshint boss: true */
+function Highlighter() {}
 
-NGI.Highlighter = (function() {
-
-	function Highlighter() {}
-
-	function offsets(node) {
-		var vals = {
-			x: node.offsetLeft,
-			y: node.offsetTop,
-			w: node.offsetWidth,
-			h: node.offsetHeight
-		};
-		while (node = node.offsetParent) {
-			vals.x += node.offsetLeft;
-			vals.y += node.offsetTop;
-		}
-		return vals;
+function offsets(node) {
+	var vals = {
+		x: node.offsetLeft,
+		y: node.offsetTop,
+		w: node.offsetWidth,
+		h: node.offsetHeight
+	};
+	while (node = node.offsetParent) {
+		vals.x += node.offsetLeft;
+		vals.y += node.offsetTop;
 	}
+	return vals;
+}
 
-	var hls = [];
-	Highlighter.hl = function(node, label) {
-		var box = document.createElement('div');
-		box.className = 'ngi-hl ngi-hl-scope';
-		if (label) {
-			box.textContent = label;
-		}
-		var pos = offsets(node);
-		box.style.left = pos.x + 'px';
-		box.style.top = pos.y + 'px';
-		box.style.width = pos.w + 'px';
-		box.style.height = pos.h + 'px';
-		document.body.appendChild(box);
-		hls.push(box);
-		return box;
-	};
+var hls = [];
+Highlighter.hl = function(node, label) {
+	var box = document.createElement('div');
+	box.className = 'ngi-hl ngi-hl-scope';
+	if (label) {
+		box.textContent = label;
+	}
+	var pos = offsets(node);
+	box.style.left = pos.x + 'px';
+	box.style.top = pos.y + 'px';
+	box.style.width = pos.w + 'px';
+	box.style.height = pos.h + 'px';
+	document.body.appendChild(box);
+	hls.push(box);
+	return box;
+};
 
-	Highlighter.clear = function() {
-		var box;
-		while (box = hls.pop()) {
-			box.parentNode.removeChild(box);
-		}
-	};
+Highlighter.clear = function() {
+	var box;
+	while (box = hls.pop()) {
+		box.parentNode.removeChild(box);
+	}
+};
 
-	return Highlighter;
-
-})();
+module.exports = Highlighter;

--- a/src/js/Inspector.js
+++ b/src/js/Inspector.js
@@ -1,13 +1,10 @@
-/* jshint strict: false */
+var NGI = {
+	InspectorPane: require('./InspectorPane'),
+	App: require('./App'),
+	Scope: require('./Scope')
+};
 
-var NGI = {};
-
-NGI.newID = (function() {
-	var id = 0;
-	return function() { return id++; };
-})();
-
-NGI.Inspector = function() {
+module.exports = function() {
 
 	// Settings defaults
 	this.settings = {

--- a/src/js/InspectorAgent.js
+++ b/src/js/InspectorAgent.js
@@ -1,173 +1,169 @@
-/* global NGI */
-/* jshint strict: false */
-/* jshint expr: true */
-/* jshint boss: true */
-
 // `NGi.InspectorAgent` is responsible for the page introspection (Scope and DOM
 // traversal)
 
-NGI.InspectorAgent = (function() {
+var NGI = {
+	Scope: require('./Scope')
+};
 
-	function InspectorAgent() {}
+function InspectorAgent() {}
 
-	function traverseDOM(app, node) {
+function traverseDOM(app, node) {
 
-		// Counter for the recursions being scheduled with setTimeout
-		var nodeQueue = 1;
-		traverse(node, app);
+	// Counter for the recursions being scheduled with setTimeout
+	var nodeQueue = 1;
+	traverse(node, app);
 
-		// The recursive DOM traversal function
-		function traverse(node, app) {
+	// The recursive DOM traversal function
+	function traverse(node, app) {
 
-			// We can skip all nodeTypes except ELEMENT and DOCUMENT nodes
-			if (node.nodeType === Node.ELEMENT_NODE ||
-				 node.nodeType === Node.DOCUMENT_NODE) {
+		// We can skip all nodeTypes except ELEMENT and DOCUMENT nodes
+		if (node.nodeType === Node.ELEMENT_NODE ||
+			 node.nodeType === Node.DOCUMENT_NODE) {
 
-				// Wrap the DOM node to get access to angular.element methods
-				var $node = window.angular.element(node);
+			// Wrap the DOM node to get access to angular.element methods
+			var $node = window.angular.element(node);
 
-				var nodeData = $node.data();
+			var nodeData = $node.data();
 
-				// If there's no AngularJS metadata in the node .data() store, we
-				// just move on
-				if (nodeData && Object.keys(nodeData).length > 0) {
+			// If there's no AngularJS metadata in the node .data() store, we
+			// just move on
+			if (nodeData && Object.keys(nodeData).length > 0) {
 
-					// Match nodes with scopes attached to the relevant TreeViewItem
-					var $scope = nodeData.$scope;
-					if ($scope) {
-						var scopeMatch = NGI.Scope.get($scope.$id);
-						if (scopeMatch) {
-							scopeMatch.setNode(node);
-							app.probe(node, scopeMatch, false);
-						}
-					}
-
-					// Match nodes with isolate scopes attached to the relevant
-					// TreeViewItem
-					if ($node.isolateScope) {
-						var $isolate = $node.isolateScope();
-						if ($isolate) {	
-							var isolateMatch = NGI.Scope.get($isolate.$id);
-							if (isolateMatch) {
-								isolateMatch.setNode(node);
-								app.probe(node, isolateMatch, true);
-							}
-						}
+				// Match nodes with scopes attached to the relevant TreeViewItem
+				var $scope = nodeData.$scope;
+				if ($scope) {
+					var scopeMatch = NGI.Scope.get($scope.$id);
+					if (scopeMatch) {
+						scopeMatch.setNode(node);
+						app.probe(node, scopeMatch, false);
 					}
 				}
 
-				if (node.firstChild) {
-					var child = node.firstChild;
-					do {
-						// Increment the probed nodes counter, will be used for reporting
-						nodeQueue++;
-
-						// setTimeout is used to make the traversal asyncrhonous, keeping
-						// the browser UI responsive during traversal.
-						setTimeout(traverse.bind(this, child, app));
-					} while (child = child.nextSibling);
+				// Match nodes with isolate scopes attached to the relevant
+				// TreeViewItem
+				if ($node.isolateScope) {
+					var $isolate = $node.isolateScope();
+					if ($isolate) {	
+						var isolateMatch = NGI.Scope.get($isolate.$id);
+						if (isolateMatch) {
+							isolateMatch.setNode(node);
+							app.probe(node, isolateMatch, true);
+						}
+					}
 				}
-
 			}
+
+			if (node.firstChild) {
+				var child = node.firstChild;
+				do {
+					// Increment the probed nodes counter, will be used for reporting
+					nodeQueue++;
+
+					// setTimeout is used to make the traversal asyncrhonous, keeping
+					// the browser UI responsive during traversal.
+					setTimeout(traverse.bind(this, child, app));
+				} while (child = child.nextSibling);
+			}
+
+		}
+		nodeQueue--;
+		if (--nodeQueue === 0) {
+			// Done
+		}
+		
+	}
+}
+
+function traverseScopes(ngScope, app, callback) {
+
+	var scopeQueue = 1;
+	traverse(ngScope);
+
+	function traverse(ngScope) {
+		var scopeRep = NGI.Scope.instance(app, ngScope);
+		scopeRep.startObserver();
+
+		if (ngScope.$parent) {
+			var parent = NGI.Scope.get(ngScope.$parent.$id).view;
+			parent.addChild(scopeRep.view);
+		} else {
+			app.view.addChild(scopeRep.view);
+		}
+
+		var child = ngScope.$$childHead;
+		if (child) {
+			do {
+				scopeQueue++;
+				setTimeout(traverse.bind(this, child));
+			} while (child = child.$$nextSibling);
+		}
+
+		if (--scopeQueue === 0) {
+			// Done
+			if (typeof callback === 'function') callback();
+		}
+	}
+}
+
+// Adds the TreeView item for the AngularJS application bootstrapped at
+// the `node` argument.
+InspectorAgent.inspectApp = function(app) {
+
+	window.ngInspector.pane.treeView.appendChild(app.view.element);
+
+	// With the root Node for the app, we retrieve the $rootScope
+	var $node = window.angular.element(app.node);
+	var $rootScope = $node.data('$scope').$root;
+
+	// Then start the Scope traversal mechanism
+	traverseScopes($rootScope, app, function() {
+
+		// Once the Scope traversal is complete, the DOM traversal starts
+		traverseDOM(app, app.node);
+		
+	});
+};
+
+InspectorAgent.inspectScope = function(app, scope) {
+	traverseScopes(scope, app);
+};
+
+InspectorAgent.inspectNode = function(app, node) {
+	traverseDOM(app, node);
+};
+
+InspectorAgent.findApps = function (App) {
+
+	var nodeQueue = 1;
+
+	// DOM Traversal to find AngularJS App root elements. Traversal is
+	// interrupted when an App is found (traversal inside the App is done by the
+	// InspectorAgent.inspectApp method)
+	function traverse(node) {
+
+		if (node.nodeType === Node.ELEMENT_NODE ||
+			 node.nodeType === Node.DOCUMENT_NODE) {
+
+			var $node = window.angular.element(node);
+
+			if ($node.data('$injector')) {
+				App.bootstrap(node);
+			} else if (node.firstChild) {
+				var child = node.firstChild;
+				do {
+					nodeQueue++;
+					setTimeout(traverse.bind(this, child), 4);
+				} while (child = child.nextSibling);
+			}
+
 			nodeQueue--;
 			if (--nodeQueue === 0) {
 				// Done
 			}
-			
 		}
 	}
 
-	function traverseScopes(ngScope, app, callback) {
+	traverse(document);
+};
 
-		var scopeQueue = 1;
-		traverse(ngScope);
-
-		function traverse(ngScope) {
-			var scopeRep = NGI.Scope.instance(app, ngScope);
-			scopeRep.startObserver();
-
-			if (ngScope.$parent) {
-				var parent = NGI.Scope.get(ngScope.$parent.$id).view;
-				parent.addChild(scopeRep.view);
-			} else {
-				app.view.addChild(scopeRep.view);
-			}
-
-			var child = ngScope.$$childHead;
-			if (child) {
-				do {
-					scopeQueue++;
-					setTimeout(traverse.bind(this, child));
-				} while (child = child.$$nextSibling);
-			}
-
-			if (--scopeQueue === 0) {
-				// Done
-				if (typeof callback === 'function') callback();
-			}
-		}
-	}
-
-	// Adds the TreeView item for the AngularJS application bootstrapped at
-	// the `node` argument.
-	InspectorAgent.inspectApp = function(app) {
-
-		window.ngInspector.pane.treeView.appendChild(app.view.element);
-
-		// With the root Node for the app, we retrieve the $rootScope
-		var $node = window.angular.element(app.node);
-		var $rootScope = $node.data('$scope').$root;
-
-		// Then start the Scope traversal mechanism
-		traverseScopes($rootScope, app, function() {
-
-			// Once the Scope traversal is complete, the DOM traversal starts
-			traverseDOM(app, app.node);
-			
-		});
-	};
-
-	InspectorAgent.inspectScope = function(app, scope) {
-		traverseScopes(scope, app);
-	};
-
-	InspectorAgent.inspectNode = function(app, node) {
-		traverseDOM(app, node);
-	};
-
-	InspectorAgent.findApps = function () {
-
-		var nodeQueue = 1;
-
-		// DOM Traversal to find AngularJS App root elements. Traversal is
-		// interrupted when an App is found (traversal inside the App is done by the
-		// InspectorAgent.inspectApp method)
-		function traverse(node) {
-
-			if (node.nodeType === Node.ELEMENT_NODE ||
-				 node.nodeType === Node.DOCUMENT_NODE) {
-
-				var $node = window.angular.element(node);
-
-				if ($node.data('$injector')) {
-					NGI.App.bootstrap(node);
-				} else if (node.firstChild) {
-					var child = node.firstChild;
-					do {
-						nodeQueue++;
-						setTimeout(traverse.bind(this, child), 4);
-					} while (child = child.nextSibling);
-				}
-
-				nodeQueue--;
-				if (--nodeQueue === 0) {
-					// Done
-				}
-			}
-		}
-
-		traverse(document);
-	};
-
-	return InspectorAgent;
-})();
+module.exports = InspectorAgent;

--- a/src/js/InspectorPane.js
+++ b/src/js/InspectorPane.js
@@ -1,6 +1,3 @@
-/* global NGI */
-/* jshint strict: false */
-
 /**
  * `NGI.InspectorPane` is responsible for the root element and basic interaction
  * with the pane (in practice, a <div>) injected in the page DOM, such as
@@ -8,7 +5,7 @@
  * level of child views.
  */
 
-NGI.InspectorPane = function() {
+module.exports = function() {
 
 	// The width of the pane can be resized by the user, and is persisted via
 	// localStorage

--- a/src/js/Model.js
+++ b/src/js/Model.js
@@ -1,120 +1,120 @@
-/* global NGI */
-/* jshint strict: false */
+var NGI = {
+	TreeView: require('./TreeView'),
+	ModelMixin: require('./ModelMixin'),
+	Utils: require('./Utils')
+};
 
-NGI.Model = (function() {
+function Model(key, value, depth) {
 
-	function Model(key, value, depth) {
+	this.key = key;
+	this.value = value;
+	this.ngiType = 'Model';
 
-		this.key = key;
-		this.value = value;
+	this.view = NGI.TreeView.modelItem(key, value, depth);
 
-		this.view = NGI.TreeView.modelItem(key, value, depth);
+	var valSpan = document.createElement('span');
+	valSpan.className = 'ngi-value';
 
-		var valSpan = document.createElement('span');
-		valSpan.className = 'ngi-value';
+	NGI.ModelMixin.extend(this);
 
-		NGI.ModelMixin.extend(this);
+	this.setValue = function(newValue) {
 
-		this.setValue = function(newValue) {
+		this.value = value = newValue;
 
-			this.value = value = newValue;
-
-			// String
-			if (angular.isString(value)) {
-				this.view.setType('ngi-model-string');
-				if (value.trim().length > 25) {
-					valSpan.textContent = '"' + value.trim().substr(0, 25) + ' (...)"';
-					this.view.setIndicator(value.length);
-				}
-				else {
-					valSpan.textContent = '"' + value.trim() + '"';
-				}
+		// String
+		if (angular.isString(value)) {
+			this.view.setType('ngi-model-string');
+			if (value.trim().length > 25) {
+				valSpan.textContent = '"' + value.trim().substr(0, 25) + ' (...)"';
+				this.view.setIndicator(value.length);
 			}
-
-			// Function
-			else if (angular.isFunction(value)) {
-				this.view.setType('ngi-model-function');
-				var args = NGI.Utils.annotate(value).join(', ');
-				valSpan.textContent = 'function(' + args + ') {...}';
-			}
-
-			// Circular
-			else if (depth.indexOf(value) >= 0) {
-				this.view.setType('ngi-model-circular');
-				valSpan.textContent = 'circular reference';
-			}
-
-			// NULL
-			else if (value === null) {
-				this.view.setType('ngi-model-null');
-				valSpan.textContent = 'null';
-			}
-
-			// Array
-			else if (angular.isArray(value)) {
-				this.view.setType('ngi-model-array');
-				var length = value.length;
-				if (length === 0) {
-					valSpan.textContent = '[ ]';
-				}
-				else {
-					valSpan.textContent = '[...]';
-					this.view.setIndicator(length);
-				}
-				this.view.makeCollapsible(true, true);
-				this.update(value, depth.concat([this.value]));
-			}
-
-			// DOM Element
-			else if (angular.isElement(value)) {
-				this.view.setType('ngi-model-element');
-				valSpan.textContent = '<' + value.tagName + '>';
-			}
-
-			// Object
-			else if (angular.isObject(value)) {
-				this.view.setType('ngi-model-object');
-				var length = Object.keys(value).length;
-				if (length === 0) {
-					valSpan.textContent = '{ }';
-				}
-				else {
-					valSpan.textContent = '{...}';
-					this.view.setIndicator(length);
-				}
-				this.view.makeCollapsible(true, true);
-				this.update(value, depth.concat([this.value]));
-			}
-
-			// Boolean
-			else if (typeof value === 'boolean') {
-				this.view.setType('ngi-model-boolean');
-				valSpan.textContent = value;
-			}
-
-			// Number
-			else if (angular.isNumber(value)) {
-				this.view.setType('ngi-model-number');
-				valSpan.textContent = value;
-			}
-
-			// Undefined
 			else {
-				this.view.setType('ngi-model-undefined');
-				valSpan.textContent = 'undefined';
+				valSpan.textContent = '"' + value.trim() + '"';
 			}
+		}
 
-		};
-		this.setValue(value);
+		// Function
+		else if (angular.isFunction(value)) {
+			this.view.setType('ngi-model-function');
+			var args = NGI.Utils.annotate(value).join(', ');
+			valSpan.textContent = 'function(' + args + ') {...}';
+		}
 
-		this.view.label.appendChild(document.createTextNode(' '));
-		this.view.label.appendChild(valSpan);
-	}
+		// Circular
+		else if (depth.indexOf(value) >= 0) {
+			this.view.setType('ngi-model-circular');
+			valSpan.textContent = 'circular reference';
+		}
 
-	Model.instance = function(key, value, depth) {
-		return new Model(key, value, depth);
+		// NULL
+		else if (value === null) {
+			this.view.setType('ngi-model-null');
+			valSpan.textContent = 'null';
+		}
+
+		// Array
+		else if (angular.isArray(value)) {
+			this.view.setType('ngi-model-array');
+			var length = value.length;
+			if (length === 0) {
+				valSpan.textContent = '[ ]';
+			}
+			else {
+				valSpan.textContent = '[...]';
+				this.view.setIndicator(length);
+			}
+			this.view.makeCollapsible(true, true);
+			this.update(value, depth.concat([this.value]), Model);
+		}
+
+		// DOM Element
+		else if (angular.isElement(value)) {
+			this.view.setType('ngi-model-element');
+			valSpan.textContent = '<' + value.tagName + '>';
+		}
+
+		// Object
+		else if (angular.isObject(value)) {
+			this.view.setType('ngi-model-object');
+			var length = Object.keys(value).length;
+			if (length === 0) {
+				valSpan.textContent = '{ }';
+			}
+			else {
+				valSpan.textContent = '{...}';
+				this.view.setIndicator(length);
+			}
+			this.view.makeCollapsible(true, true);
+			this.update(value, depth.concat([this.value]), Model);
+		}
+
+		// Boolean
+		else if (typeof value === 'boolean') {
+			this.view.setType('ngi-model-boolean');
+			valSpan.textContent = value;
+		}
+
+		// Number
+		else if (angular.isNumber(value)) {
+			this.view.setType('ngi-model-number');
+			valSpan.textContent = value;
+		}
+
+		// Undefined
+		else {
+			this.view.setType('ngi-model-undefined');
+			valSpan.textContent = 'undefined';
+		}
+
 	};
+	this.setValue(value);
 
-	return Model;
+	this.view.label.appendChild(document.createTextNode(' '));
+	this.view.label.appendChild(valSpan);
+}
 
-})();
+Model.instance = function(key, value, depth) {
+	return new Model(key, value, depth);
+};
+
+module.exports = Model;

--- a/src/js/ModelMixin.js
+++ b/src/js/ModelMixin.js
@@ -1,86 +1,79 @@
-/* global NGI */
-/* jshint strict: false */
-
-NGI.ModelMixin = (function() {
-
-	// Keturns the keys for the user defined models in the scope excluding keys
-	// created by AngularJS or the `this` keyword, or the elements
-	// in an array or object
-	function getKeys(values) {
-		var keys = [];
-		for (var key in values) {
-			if (values.hasOwnProperty(key) && !/^\$/.test(key) && key !== 'this') {
-				keys.push(key);
-			}
+// Keturns the keys for the user defined models in the scope excluding keys
+// created by AngularJS or the `this` keyword, or the elements
+// in an array or object
+function getKeys(values) {
+	var keys = [];
+	for (var key in values) {
+		if (values.hasOwnProperty(key) && !/^\$/.test(key) && key !== 'this') {
+			keys.push(key);
 		}
-		return keys;
+	}
+	return keys;
+}
+
+function arrayDiff(a, b) {
+	var i, ret = { added: [], removed: [], existing: [] };
+
+	// Iterate through b checking for added and existing elements
+	for (i = 0; i < b.length; i++) {
+		if (a.indexOf(b[i]) < 0) {
+			ret.added.push(b[i]);
+		} else {
+			ret.existing.push(b[i]);
+		}
 	}
 
-	function arrayDiff(a, b) {
-		var i, ret = { added: [], removed: [], existing: [] };
-
-		// Iterate through b checking for added and existing elements
-		for (i = 0; i < b.length; i++) {
-			if (a.indexOf(b[i]) < 0) {
-				ret.added.push(b[i]);
-			} else {
-				ret.existing.push(b[i]);
-			}
+	// Iterate through a checking for removed elements
+	for (i = 0; i < a.length; i++) {
+		if (b.indexOf(a[i]) < 0) {
+			ret.removed.push(a[i]);
 		}
-
-		// Iterate through a checking for removed elements
-		for (i = 0; i < a.length; i++) {
-			if (b.indexOf(a[i]) < 0) {
-				ret.removed.push(a[i]);
-			}
-		}
-
-		return ret;
 	}
 
-	function ModelMixin() {}
+	return ret;
+}
 
-	ModelMixin.update = function(values, depth) {
+function ModelMixin() {}
 
-		if (typeof this.modelObjs === 'undefined') this.modelObjs = {};
-		if (typeof this.modelKeys === 'undefined') this.modelKeys = [];
+ModelMixin.update = function(values, depth, Model) {
 
-		var newKeys = getKeys(values),
-				diff = arrayDiff(this.modelKeys, newKeys),
-				i, key;
+	if (typeof this.modelObjs === 'undefined') this.modelObjs = {};
+	if (typeof this.modelKeys === 'undefined') this.modelKeys = [];
 
-		// Removed keys
-		for (i = 0; i < diff.removed.length; i++) {
-			var key = diff.removed[i];
-			this.modelObjs[key].view.destroy();
-			delete this.modelObjs[key];
+	var newKeys = getKeys(values),
+			diff = arrayDiff(this.modelKeys, newKeys),
+			i, key;
+
+	// Removed keys
+	for (i = 0; i < diff.removed.length; i++) {
+		var key = diff.removed[i];
+		this.modelObjs[key].view.destroy();
+		delete this.modelObjs[key];
+	}
+	
+	// New keys
+	for (i = 0; i < diff.added.length; i++) {
+		key = diff.added[i];
+		this.modelObjs[key] = Model.instance(key, values[key], depth.concat([values]));
+		var insertAtTop = this.ngiType === 'Scope';
+		this.view.addChild(this.modelObjs[key].view, insertAtTop);
+	}
+
+	// Updated keys
+	for (i = 0; i < diff.existing.length; i++) {
+		key = diff.existing[i];
+		if (!this.modelObjs[key]) {
+			var inst = this.ngiType === 'Scope' ? 'Scope' : this.ngiType === 'Model' ? 'Model' : 'UNKNOWN INSTANCE';
+			continue;
 		}
-		
-		// New keys
-		for (i = 0; i < diff.added.length; i++) {
-			key = diff.added[i];
-			this.modelObjs[key] = NGI.Model.instance(key, values[key], depth.concat([values]));
-			var insertAtTop = this instanceof NGI.Scope;
-			this.view.addChild(this.modelObjs[key].view, insertAtTop);
-		}
+		this.modelObjs[key].setValue(values[key]);
+	}
 
-		// Updated keys
-		for (i = 0; i < diff.existing.length; i++) {
-			key = diff.existing[i];
-			if (!this.modelObjs[key]) {
-				var inst = this instanceof NGI.Scope ? 'Scope' : this instanceof NGI.Model ? 'Model' : 'UNKNOWN INSTANCE';
-				continue;
-			}
-			this.modelObjs[key].setValue(values[key]);
-		}
+	this.modelKeys = newKeys;
+};
 
-		this.modelKeys = newKeys;
-	};
+ModelMixin.extend = function(obj) {
+	obj.update = ModelMixin.update.bind(obj);
+};
 
-	ModelMixin.extend = function(obj) {
-		obj.update = ModelMixin.update.bind(obj);
-	};
-
-	return ModelMixin;
-
-})();
+module.exports = ModelMixin;

--- a/src/js/Module.js
+++ b/src/js/Module.js
@@ -1,44 +1,40 @@
-/* global NGI */
-/* jshint strict: false */
-/* jshint expr: true */
+var NGI = {
+	Service: require('./Service')
+};
 
-NGI.Module = (function() {
+function Module(app, name) {
 
-	function Module(app, name) {
+	// The AngularJS module name
+	this.name = name;
 
-		// The AngularJS module name
-		this.name = name;
+	// Array with `NGI.Module` instance references
+	this.requires = [];
 
-		// Array with `NGI.Module` instance references
-		this.requires = [];
+	// The AngularJS module instance
+	this.ngModule = window.angular.module(name);
 
-		// The AngularJS module instance
-		this.ngModule = window.angular.module(name);
+	// `NGI.Service` instances representing services defined in this module
+	this.services = NGI.Service.parseQueue(app, this.ngModule);
+}
 
-		// `NGI.Service` instances representing services defined in this module
-		this.services = NGI.Service.parseQueue(app, this.ngModule);
+// A cache with all NGI.Module instances
+var moduleCache = [];
+
+Module.register = function(app, name) {
+	// Ensure only a single `NGI.Module` instance exists for each AngularJS
+	// module name
+	if (typeof name === typeof '' && !moduleCache[name]) {
+		moduleCache[name] = new Module(app, name);
+
+		// Register the dependencies
+		var requires = moduleCache[name].ngModule.requires;
+		for (var i = 0; i < requires.length; i++) {
+			var dependency = Module.register(app, requires[i]);
+			moduleCache[name].requires.push(dependency);
+		}
 	}
 
-	// A cache with all NGI.Module instances
-	var moduleCache = [];
+	return moduleCache[name];
+};
 
-	Module.register = function(app, name) {
-		// Ensure only a single `NGI.Module` instance exists for each AngularJS
-		// module name
-		if (typeof name === typeof '' && !moduleCache[name]) {
-			moduleCache[name] = new Module(app, name);
-
-			// Register the dependencies
-			var requires = moduleCache[name].ngModule.requires;
-			for (var i = 0; i < requires.length; i++) {
-				var dependency = Module.register(app, requires[i]);
-				moduleCache[name].requires.push(dependency);
-			}
-		}
-
-		return moduleCache[name];
-	};
-
-	return Module;
-
-})();
+module.exports = Module;

--- a/src/js/Scope.js
+++ b/src/js/Scope.js
@@ -1,117 +1,117 @@
-/* global NGI */
-/* jshint strict: false */
-/* jshint boss: true */
+var NGI = {
+	TreeView: require('./TreeView'),
+	ModelMixin: require('./ModelMixin'),
+	InspectorAgent: require('./InspectorAgent'),
+	Model: require('./Model')
+};
 
-NGI.Scope = (function() {
+function Scope(app, ngScope, isIsolate) {
 
-	function Scope(app, ngScope, isIsolate) {
+	var angular = window.angular;
 
-		var angular = window.angular;
+	this.app = app;
+	this.ngScope = ngScope;
+	this.ngiType = 'Scope';
 
-		this.app = app;
-		this.ngScope = ngScope;
+	// Calculate the scope depth in the tree to determine the intendation level
+	// in the TreeView
+	var reference = ngScope;
+	var depth = [reference];
+	while (reference = reference.$parent) { depth.push(reference); }
 
-		// Calculate the scope depth in the tree to determine the intendation level
-		// in the TreeView
-		var reference = ngScope;
-		var depth = [reference];
-		while (reference = reference.$parent) { depth.push(reference); }
+	// Instantiate and expose the TreeViewItem representing the scope
+	var view = this.view = NGI.TreeView.scopeItem(ngScope.$id, depth, isIsolate);
+	if (isIsolate) this.view.element.classList.add('ngi-isolate-scope');
 
-		// Instantiate and expose the TreeViewItem representing the scope
-		var view = this.view = NGI.TreeView.scopeItem(ngScope.$id, depth, isIsolate);
-		if (isIsolate) this.view.element.classList.add('ngi-isolate-scope');
+	// Called when the `NGI.InspectorAgent` DOM traversal finds a Node match
+	// for the scope
+	this.setNode = function(node) {
+		this.node = this.view.node = node;
+	};
 
-		// Called when the `NGI.InspectorAgent` DOM traversal finds a Node match
-		// for the scope
-		this.setNode = function(node) {
-			this.node = this.view.node = node;
-		};
-
-		function childScopeIds() {
-			if (!ngScope.$$childHead) return [];
-			var childKeys = [];
-			var childScope = ngScope.$$childHead;
-			do {
-				childKeys.push(childScope.$id);
-			} while (childScope = childScope.$$nextSibling);
-			return childKeys;
-		}
-
-		var oldChildIds = childScopeIds();
-
-		var destroyDeregister = angular.noop;
-		var watchDeregister = angular.noop;
-		var observerOn = false;
-
-		NGI.ModelMixin.extend(this);
-		this.update(ngScope, depth);
-
-		this.startObserver = function() {
-			if (observerOn === false) {
-				var scopeObj = this;
-				destroyDeregister = ngScope.$on('$destroy', function() {
-					view.destroy();
-				});
-				watchDeregister = ngScope.$watch(function() {
-
-					// Scopes: basic check for mutations in the direct child scope list
-					var newChildIds = childScopeIds();
-					if (!angular.equals(oldChildIds, newChildIds)) {
-						NGI.InspectorAgent.inspectScope(app, ngScope);
-					}
-					oldChildIds = newChildIds;
-
-					// Models
-					scopeObj.update(ngScope, depth);
-
-				});
-				observerOn = true;
-			}
-		};
-
-		this.stopObserver = function() {
-			if (observerOn === true) {
-				if (typeof destroyDeregister === 'function') {
-					destroyDeregister.apply();
-				}
-				if (typeof watchDeregister === 'function') {
-					watchDeregister.apply();
-				}
-				observerOn = false;
-			}
-		};
-
+	function childScopeIds() {
+		if (!ngScope.$$childHead) return [];
+		var childKeys = [];
+		var childScope = ngScope.$$childHead;
+		do {
+			childKeys.push(childScope.$id);
+		} while (childScope = childScope.$$nextSibling);
+		return childKeys;
 	}
 
-	// To easily retrieve an `NGI.Scope` instance by the scope id, we keep a
-	// cache of created instances
-	var scopeCache = {};
+	var oldChildIds = childScopeIds();
 
-	// Expose stopObservers to stop observers from all scopes in `scopeCache` when
-	// the inspector pane is toggled off
-	Scope.stopObservers = function() {
-		for (var i = 0; i < scopeCache.length; i++) {
-			scopeCache[i].stopObserver();
+	var destroyDeregister = angular.noop;
+	var watchDeregister = angular.noop;
+	var observerOn = false;
+
+	NGI.ModelMixin.extend(this);
+	this.update(ngScope, depth, NGI.Model);
+
+	this.startObserver = function() {
+		if (observerOn === false) {
+			var scopeObj = this;
+			destroyDeregister = ngScope.$on('$destroy', function() {
+				view.destroy();
+			});
+			watchDeregister = ngScope.$watch(function() {
+
+				// Scopes: basic check for mutations in the direct child scope list
+				var newChildIds = childScopeIds();
+				if (!angular.equals(oldChildIds, newChildIds)) {
+					NGI.InspectorAgent.inspectScope(app, ngScope);
+				}
+				oldChildIds = newChildIds;
+
+				// Models
+				scopeObj.update(ngScope, depth, NGI.Model);
+
+			});
+			observerOn = true;
 		}
 	};
 
-	// Returns an instance of `NGI.Scope` representing the AngularJS scope with
-	// the id
-	Scope.get = function(id) {
-		return scopeCache[id];
-	};
-
-	// This is the method used by `NGI.InspectorAgent` to instantiate the
-	// `NGI.Scope` object
-	Scope.instance = function(app, ngScope, isIsolate) {
-		if (scopeCache[ngScope.$id]) {
-			return scopeCache[ngScope.$id];
+	this.stopObserver = function() {
+		if (observerOn === true) {
+			if (typeof destroyDeregister === 'function') {
+				destroyDeregister.apply();
+			}
+			if (typeof watchDeregister === 'function') {
+				watchDeregister.apply();
+			}
+			observerOn = false;
 		}
-		var scope = new NGI.Scope(app, ngScope, isIsolate);
-		scopeCache[ngScope.$id] = scope;
-		return scope;
 	};
 
-	return Scope;
+}
 
-})();
+// To easily retrieve an `NGI.Scope` instance by the scope id, we keep a
+// cache of created instances
+var scopeCache = {};
+
+// Expose stopObservers to stop observers from all scopes in `scopeCache` when
+// the inspector pane is toggled off
+Scope.stopObservers = function() {
+	for (var i = 0; i < scopeCache.length; i++) {
+		scopeCache[i].stopObserver();
+	}
+};
+
+// Returns an instance of `NGI.Scope` representing the AngularJS scope with
+// the id
+Scope.get = function(id) {
+	return scopeCache[id];
+};
+
+// This is the method used by `NGI.InspectorAgent` to instantiate the
+// `NGI.Scope` object
+Scope.instance = function(app, ngScope, isIsolate) {
+	if (scopeCache[ngScope.$id]) {
+		return scopeCache[ngScope.$id];
+	}
+	var scope = new Scope(app, ngScope, isIsolate);
+	scopeCache[ngScope.$id] = scope;
+	return scope;
+};
+
+module.exports = Scope;

--- a/src/js/Service.js
+++ b/src/js/Service.js
@@ -1,49 +1,74 @@
-/* global NGI */
-/* jshint strict: false */
-/* jshint shadow: true */
+var NGI = {
+	Utils: require('./Utils')
+};
 
-NGI.Service = (function() {
+var CLASS_DIRECTIVE_REGEXP = /(([\d\w\-_]+)(?:\:([^;]+))?;?)/;
 
-	var CLASS_DIRECTIVE_REGEXP = /(([\d\w\-_]+)(?:\:([^;]+))?;?)/;
+function Service(app, module, invoke) {
+	this.provider = invoke[0];
+	this.type = invoke[1];
+	this.definition = invoke[2];
+	this.name = (typeof this.definition[0] === typeof '') ? this.definition[0] : null;
+	this.factory = this.definition[1];
+	
+	switch(this.provider) {
+		case '$compileProvider':
 
-	function Service(app, module, invoke) {
-		this.provider = invoke[0];
-		this.type = invoke[1];
-		this.definition = invoke[2];
-		this.name = (typeof this.definition[0] === typeof '') ? this.definition[0] : null;
-		this.factory = this.definition[1];
-		
-		switch(this.provider) {
-			case '$compileProvider':
+			var dir;
 
-				var dir;
+			try {
+				dir = app.$injector.invoke(this.factory);
+			} catch(err) {
+				return console.warn(
+					'ng-inspector: An error occurred attempting to invoke directive: ' +
+					(this.name || '(unknown)'),
+					err
+				);
+			}
 
-				try {
-					dir = app.$injector.invoke(this.factory);
-				} catch(err) {
-					return console.warn(
-						'ng-inspector: An error occurred attempting to invoke directive: ' +
-						(this.name || '(unknown)'),
-						err
-					);
+			if (!dir) dir = {};
+			var restrict = dir.restrict || 'AE';
+			var name = this.name;
+
+			app.registerProbe(function(node, scope, isIsolate) {
+
+				if (node === document) {
+					node = document.getElementsByTagName('html')[0];
 				}
 
-				if (!dir) dir = {};
-				var restrict = dir.restrict || 'AE';
-				var name = this.name;
-
-				app.registerProbe(function(node, scope, isIsolate) {
-
-					if (node === document) {
-						node = document.getElementsByTagName('html')[0];
+				// Test for Attribute Comment directives (with replace:true for the
+				// latter)
+				if (restrict.indexOf('A') > -1 ||
+					(dir.replace === true && restrict.indexOf('M') > -1)) {
+					for (var i = 0; i < node.attributes.length; i++) {
+						var normalized = NGI.Utils.directiveNormalize(node.attributes[i].name);
+						if (normalized === name) {
+							if (!isIsolate && dir.scope === true ||
+								isIsolate && typeof dir.scope === typeof {}) {
+								scope.view.addAnnotation(name, Service.DIR);
+							}
+						}
 					}
+				}
 
-					// Test for Attribute Comment directives (with replace:true for the
-					// latter)
-					if (restrict.indexOf('A') > -1 ||
-						(dir.replace === true && restrict.indexOf('M') > -1)) {
-						for (var i = 0; i < node.attributes.length; i++) {
-							var normalized = NGI.Utils.directiveNormalize(node.attributes[i].name);
+				// Test for Element directives
+				if (restrict.indexOf('E') > -1) {
+					var normalized = NGI.Utils.directiveNormalize(node.tagName.toLowerCase());
+					if (normalized === name) {
+						if (!isIsolate && dir.scope === true ||
+							isIsolate && typeof dir.scope === typeof {}) {
+							scope.view.addAnnotation(name, Service.DIR);
+						}
+					}
+				}
+
+				// Test for Class directives
+				if (restrict.indexOf('C') > -1) {
+					var matches = CLASS_DIRECTIVE_REGEXP.exec(node.className);
+					if (matches) {
+						for (var i = 0; i < matches.length; i++) {
+							if (!matches[i]) continue;
+							var normalized = NGI.Utils.directiveNormalize(matches[i]);
 							if (normalized === name) {
 								if (!isIsolate && dir.scope === true ||
 									isIsolate && typeof dir.scope === typeof {}) {
@@ -52,83 +77,54 @@ NGI.Service = (function() {
 							}
 						}
 					}
+				}
 
-					// Test for Element directives
-					if (restrict.indexOf('E') > -1) {
-						var normalized = NGI.Utils.directiveNormalize(node.tagName.toLowerCase());
-						if (normalized === name) {
-							if (!isIsolate && dir.scope === true ||
-								isIsolate && typeof dir.scope === typeof {}) {
-								scope.view.addAnnotation(name, Service.DIR);
-							}
-						}
-					}
+			});
+			break;
+		case '$controllerProvider':
 
-					// Test for Class directives
-					if (restrict.indexOf('C') > -1) {
-						var matches = CLASS_DIRECTIVE_REGEXP.exec(node.className);
-						if (matches) {
-							for (var i = 0; i < matches.length; i++) {
-								if (!matches[i]) continue;
-								var normalized = NGI.Utils.directiveNormalize(matches[i]);
-								if (normalized === name) {
-									if (!isIsolate && dir.scope === true ||
-										isIsolate && typeof dir.scope === typeof {}) {
-										scope.view.addAnnotation(name, Service.DIR);
-									}
-								}
-							}
-						}
-					}
+			app.registerProbe(function(node, scope) {
 
-				});
-				break;
-			case '$controllerProvider':
+				if (node === document) {
+					node = document.getElementsByTagName('html')[0];
+				}
 
-				app.registerProbe(function(node, scope) {
-
-					if (node === document) {
-						node = document.getElementsByTagName('html')[0];
-					}
-
-					// Test for the presence of the ngController directive
-					for (var i = 0; i < node.attributes.length; i++) {
-						var normalized = NGI.Utils.directiveNormalize(node.attributes[i].name);
-						if (normalized === 'ngController') {
-							scope.view.addAnnotation(node.attributes[i].value, Service.CTRL);
-						}
-					}
-
-				});
-
-				break;
-		}
-	}
-
-	Service.CTRL = 1;
-	Service.DIR = 2;
-	Service.BUILTIN = 4;
-
-	Service.parseQueue = function(app, module) {
-		var arr = [],
-				queue = module._invokeQueue,
-				tempQueue, i, j;
-		for (i = 0; i < queue.length; i++) {
-			if (queue[i][2].length === 1 && !(queue[i][2][0] instanceof Array)) {
-				for (j in queue[i][2][0]) {
-					if (Object.hasOwnProperty.call(queue[i][2][0], j)) {
-						tempQueue = queue[i].slice();
-						tempQueue[2] = [Object.keys(queue[i][2][0])[j], queue[i][2][0][j]];
-						arr.push(new Service(app, module, tempQueue));
+				// Test for the presence of the ngController directive
+				for (var i = 0; i < node.attributes.length; i++) {
+					var normalized = NGI.Utils.directiveNormalize(node.attributes[i].name);
+					if (normalized === 'ngController') {
+						scope.view.addAnnotation(node.attributes[i].value, Service.CTRL);
 					}
 				}
-			} else {
-				arr.push(new Service(app, module, queue[i]));
+
+			});
+
+			break;
+	}
+}
+
+Service.CTRL = 1;
+Service.DIR = 2;
+Service.BUILTIN = 4;
+
+Service.parseQueue = function(app, module) {
+	var arr = [],
+			queue = module._invokeQueue,
+			tempQueue, i, j;
+	for (i = 0; i < queue.length; i++) {
+		if (queue[i][2].length === 1 && !(queue[i][2][0] instanceof Array)) {
+			for (j in queue[i][2][0]) {
+				if (Object.hasOwnProperty.call(queue[i][2][0], j)) {
+					tempQueue = queue[i].slice();
+					tempQueue[2] = [Object.keys(queue[i][2][0])[j], queue[i][2][0][j]];
+					arr.push(new Service(app, module, tempQueue));
+				}
 			}
+		} else {
+			arr.push(new Service(app, module, queue[i]));
 		}
-		return arr;
-	};
+	}
+	return arr;
+};
 
-	return Service;
-
-})();
+module.exports = Service;

--- a/src/js/TreeView.js
+++ b/src/js/TreeView.js
@@ -1,198 +1,194 @@
-/* global NGI, console */
-/* jshint strict: false */
-/* jshint expr: true */
-/* jshint boss: true */
+var NGI = {
+	Service: require('./Service'),
+	Highlighter: require('./Highlighter')
+};
 
-NGI.TreeView = (function() {
+function TreeViewItem(label) {
 
-	function TreeViewItem(label) {
+	this.element = document.createElement('div');
 
-		this.element = document.createElement('div');
+	// Accepts a label DOM Node or a string
+	if (typeof label === 'string' || typeof label === 'number') {
+		this.label = document.createElement('label');
+		this.label.textContent = label;
+	} else if (!!label.tagName) {
+		this.label = label;
+	}
+	this.element.appendChild(this.label);
 
-		// Accepts a label DOM Node or a string
-		if (typeof label === 'string' || typeof label === 'number') {
-			this.label = document.createElement('label');
-			this.label.textContent = label;
-		} else if (!!label.tagName) {
-			this.label = label;
+	this.drawer = document.createElement('div');
+	this.drawer.className = 'ngi-drawer';
+	this.element.appendChild(this.drawer);
+
+	this.caret = document.createElement('span');
+	this.caret.className = 'ngi-caret';
+
+	this.length = null;
+
+	var collapsed = false;
+	this.setCollapsed = function(newState) {
+		if (collapsed = newState) {
+			this.element.classList.add('ngi-collapsed');
+			this.element.classList.remove('ngi-expanded');
+		} else {
+			this.element.classList.remove('ngi-collapsed');
+			this.element.classList.add('ngi-expanded');
 		}
-		this.element.appendChild(this.label);
+	};
+	this.toggle = function(e) {
+		e.stopPropagation();
+		this.setCollapsed(!collapsed);
+	};
+	this.caret.addEventListener('click', this.toggle.bind(this));
 
-		this.drawer = document.createElement('div');
-		this.drawer.className = 'ngi-drawer';
-		this.element.appendChild(this.drawer);
-
-		this.caret = document.createElement('span');
-		this.caret.className = 'ngi-caret';
-
-		this.length = null;
-
-		var collapsed = false;
-		this.setCollapsed = function(newState) {
-			if (collapsed = newState) {
-				this.element.classList.add('ngi-collapsed');
-				this.element.classList.remove('ngi-expanded');
-			} else {
-				this.element.classList.remove('ngi-collapsed');
-				this.element.classList.add('ngi-expanded');
-			}
-		};
-		this.toggle = function(e) {
-			e.stopPropagation();
-			this.setCollapsed(!collapsed);
-		};
-		this.caret.addEventListener('click', this.toggle.bind(this));
-
-		var isCollapsible = false;
-		this.makeCollapsible = function(collapsibleState, initialState) {
-			if (isCollapsible == collapsibleState) {
-				return;
-			}
-			if (isCollapsible = collapsibleState) {
-				this.label.appendChild(this.caret);
-				this.setCollapsed(initialState || false);
-			} else {
-				this.label.removeChild(this.caret);
-			}
+	var isCollapsible = false;
+	this.makeCollapsible = function(collapsibleState, initialState) {
+		if (isCollapsible == collapsibleState) {
+			return;
 		}
-
-		this.addChild = function(childItem, top) {
-			if (!!top) {
-				this.drawer.insertBefore(childItem.element, this.drawer.firstChild);
-			} else {
-				this.drawer.appendChild(childItem.element);
-			}
-		};
-
-		this.removeChildren = function(className) {
-			for (var i = this.drawer.childNodes.length - 1; i >= 0; i--) {
-				var child = this.drawer.childNodes[i];
-				if (child.classList.contains(className)) {
-					this.drawer.removeChild(child);
-				}
-			}
-		};
-
-		this.destroy = function() {
-			if (this.element.parentNode) {
-				this.element.parentNode.removeChild(this.element);
-			}
-		};
-
-		// Pill indicator
-		var indicator = false;
-		this.setIndicator = function(value) {
-			if (indicator && typeof value !== 'number' && typeof value !== 'string') {
-				indicator.parentNode.removeChild(indicator);
-			} else {
-				if (!indicator) {
-					indicator = document.createElement('span');
-					indicator.className = 'ngi-indicator';
-					indicator.textContent = value;
-					this.label.appendChild(indicator);
-				}
-			}
-		};
-
-		// Annotations (controller names, custom and built-in directive names)
-		var annotations = [];
-		this.addAnnotation = function(name, type) {
-			if (annotations.indexOf(name) < 0) {
-				annotations.push(name);
-			} else {
-				return;
-			}
-			var span = document.createElement('span');
-			span.className = 'ngi-annotation';
-			span.textContent = name;
-			switch(type) {
-				case NGI.Service.DIR:
-					span.classList.add('ngi-annotation-dir');
-					break;
-				case NGI.Service.BUILTIN:
-					span.classList.add('ngi-annotation-builtin');
-					break;
-				case NGI.Service.CTRL:
-					span.classList.add('ngi-annotation-ctrl');
-					break;
-			}
-			this.label.appendChild(span);
-		};
-
-		// Model types
-		var type = null;
-		this.setType = function(newType) {
-			if (type) {
-				this.element.classList.remove(type);
-			}
-			this.element.classList.add(newType);
-			type = newType;
-		};
-
+		if (isCollapsible = collapsibleState) {
+			this.label.appendChild(this.caret);
+			this.setCollapsed(initialState || false);
+		} else {
+			this.label.removeChild(this.caret);
+		}
 	}
 
-	function TreeView() {}
-
-	// Creates a TreeViewItem instance, with styling and metadata relevant for
-	// AngularJS apps
-	TreeView.appItem = function(label, node) {
-		if (node === document) node = document.querySelector('html');
-		var item = new TreeViewItem(label);
-		item.node = node;
-		item.element.className = 'ngi-app';
-		return item;
-	};
-
-	// Creates a TreeViewItem instance, with styling and metadata relevant for
-	// AngularJS scopes
-	TreeView.scopeItem = function(label, depth, isIsolate) {
-		var item = new TreeViewItem(label);
-		item.element.className = 'ngi-scope';
-		item.makeCollapsible(true, false);
-		if (isIsolate) {
-			item.element.classList.add('ngi-isolate-scope');
+	this.addChild = function(childItem, top) {
+		if (!!top) {
+			this.drawer.insertBefore(childItem.element, this.drawer.firstChild);
+		} else {
+			this.drawer.appendChild(childItem.element);
 		}
-		item.label.className = 'ngi-depth-' + depth.length;
-
-		// Highlight DOM elements the scope is attached to when hovering the item
-		// in the inspector
-		item.label.addEventListener('mouseover', function(event) {
-			var isCaret = event.target && event.target.classList.contains('ngi-caret');
-			if ( item.node && !window.ngInspector.pane.isResizing && !isCaret) {
-				var target = (item.node === document) ?
-					document.querySelector('html') : item.node;
-				// target.classList.add('ngi-highlight');
-				NGI.Highlighter.hl(target);
-			}
-		});
-		item.label.addEventListener('mouseout', function() {
-			if (item.node) {
-				NGI.Highlighter.clear();
-			}
-		});
-
-		// console.log the DOM Node this scope is attached to
-		item.label.addEventListener('click', function() {
-			console.log(item.node);
-		});
-
-		return item;
 	};
 
-	// Creates a TreeViewItem instance, with styling and metadata relevant for
-	// AngularJS models
-	TreeView.modelItem = function(key, value, depth) {
-		var item = new TreeViewItem(key + ':');
-		item.element.className = 'ngi-model';
-		item.label.className = 'ngi-depth-' + depth.length;
-
-		item.label.addEventListener('click', function() {
-			console.log(value);
-		});
-
-		return item;
+	this.removeChildren = function(className) {
+		for (var i = this.drawer.childNodes.length - 1; i >= 0; i--) {
+			var child = this.drawer.childNodes[i];
+			if (child.classList.contains(className)) {
+				this.drawer.removeChild(child);
+			}
+		}
 	};
 
-	return TreeView;
+	this.destroy = function() {
+		if (this.element.parentNode) {
+			this.element.parentNode.removeChild(this.element);
+		}
+	};
 
-})();
+	// Pill indicator
+	var indicator = false;
+	this.setIndicator = function(value) {
+		if (indicator && typeof value !== 'number' && typeof value !== 'string') {
+			indicator.parentNode.removeChild(indicator);
+		} else {
+			if (!indicator) {
+				indicator = document.createElement('span');
+				indicator.className = 'ngi-indicator';
+				indicator.textContent = value;
+				this.label.appendChild(indicator);
+			}
+		}
+	};
+
+	// Annotations (controller names, custom and built-in directive names)
+	var annotations = [];
+	this.addAnnotation = function(name, type) {
+		if (annotations.indexOf(name) < 0) {
+			annotations.push(name);
+		} else {
+			return;
+		}
+		var span = document.createElement('span');
+		span.className = 'ngi-annotation';
+		span.textContent = name;
+		switch(type) {
+			case NGI.Service.DIR:
+				span.classList.add('ngi-annotation-dir');
+				break;
+			case NGI.Service.BUILTIN:
+				span.classList.add('ngi-annotation-builtin');
+				break;
+			case NGI.Service.CTRL:
+				span.classList.add('ngi-annotation-ctrl');
+				break;
+		}
+		this.label.appendChild(span);
+	};
+
+	// Model types
+	var type = null;
+	this.setType = function(newType) {
+		if (type) {
+			this.element.classList.remove(type);
+		}
+		this.element.classList.add(newType);
+		type = newType;
+	};
+
+}
+
+function TreeView() {}
+
+// Creates a TreeViewItem instance, with styling and metadata relevant for
+// AngularJS apps
+TreeView.appItem = function(label, node) {
+	if (node === document) node = document.querySelector('html');
+	var item = new TreeViewItem(label);
+	item.node = node;
+	item.element.className = 'ngi-app';
+	return item;
+};
+
+// Creates a TreeViewItem instance, with styling and metadata relevant for
+// AngularJS scopes
+TreeView.scopeItem = function(label, depth, isIsolate) {
+	var item = new TreeViewItem(label);
+	item.element.className = 'ngi-scope';
+	item.makeCollapsible(true, false);
+	if (isIsolate) {
+		item.element.classList.add('ngi-isolate-scope');
+	}
+	item.label.className = 'ngi-depth-' + depth.length;
+
+	// Highlight DOM elements the scope is attached to when hovering the item
+	// in the inspector
+	item.label.addEventListener('mouseover', function(event) {
+		var isCaret = event.target && event.target.classList.contains('ngi-caret');
+		if ( item.node && !window.ngInspector.pane.isResizing && !isCaret) {
+			var target = (item.node === document) ?
+				document.querySelector('html') : item.node;
+			// target.classList.add('ngi-highlight');
+			NGI.Highlighter.hl(target);
+		}
+	});
+	item.label.addEventListener('mouseout', function() {
+		if (item.node) {
+			NGI.Highlighter.clear();
+		}
+	});
+
+	// console.log the DOM Node this scope is attached to
+	item.label.addEventListener('click', function() {
+		console.log(item.node);
+	});
+
+	return item;
+};
+
+// Creates a TreeViewItem instance, with styling and metadata relevant for
+// AngularJS models
+TreeView.modelItem = function(key, value, depth) {
+	var item = new TreeViewItem(key + ':');
+	item.element.className = 'ngi-model';
+	item.label.className = 'ngi-depth-' + depth.length;
+
+	item.label.addEventListener('click', function() {
+		console.log(value);
+	});
+
+	return item;
+};
+
+module.exports = TreeView;

--- a/src/js/Utils.js
+++ b/src/js/Utils.js
@@ -1,78 +1,70 @@
-/* global NGI */
-/* jshint strict: false */
-/* jshint shadow: true */
+var Utils = {};
 
-NGI.Utils = (function() {
+var SPECIAL_CHARS_REGEXP = /([\:\-\_]+(.))/g;
+var MOZ_HACK_REGEXP = /^moz([A-Z])/;
 
-	var Utils = {};
+/**
+ * Converts snake_case to camelCase.
+ * Also a special case for Moz prefix starting with upper case letter.
+ */
+Utils.camelCase = function(name) {
+	return name.
+		replace(SPECIAL_CHARS_REGEXP, function(_, separator, letter, offset) {
+			return offset ? letter.toUpperCase() : letter;
+		}).
+		replace(MOZ_HACK_REGEXP, 'Moz$1');
+}
 
-	var SPECIAL_CHARS_REGEXP = /([\:\-\_]+(.))/g;
-	var MOZ_HACK_REGEXP = /^moz([A-Z])/;
+var FN_ARGS = /^function\s*[^\(]*\(\s*([^\)]*)\)/m;
+var FN_ARG_SPLIT = /,/;
+var FN_ARG = /^\s*(_?)(\S+?)\1\s*$/;
+var STRIP_COMMENTS = /((\/\/.*$)|(\/\*[\s\S]*?\*\/))/mg;
 
-	/**
-	 * Converts snake_case to camelCase.
-	 * Also a special case for Moz prefix starting with upper case letter.
-	 */
-	Utils.camelCase = function(name) {
-		return name.
-			replace(SPECIAL_CHARS_REGEXP, function(_, separator, letter, offset) {
-				return offset ? letter.toUpperCase() : letter;
-			}).
-			replace(MOZ_HACK_REGEXP, 'Moz$1');
-	}
+var PREFIX_REGEXP = /^(x[\:\-_]|data[\:\-_])/i;
+/**
+ * Converts all accepted directives format into proper directive name.
+ * All of these will become 'myDirective':
+ *   my:Directive
+ *   my-directive
+ *   x-my-directive
+ *   data-my:directive
+ */
+Utils.directiveNormalize = function(name) {
+	return Utils.camelCase(name.replace(PREFIX_REGEXP, ''));
+}
 
-	var FN_ARGS = /^function\s*[^\(]*\(\s*([^\)]*)\)/m;
-	var FN_ARG_SPLIT = /,/;
-	var FN_ARG = /^\s*(_?)(\S+?)\1\s*$/;
-	var STRIP_COMMENTS = /((\/\/.*$)|(\/\*[\s\S]*?\*\/))/mg;
+/**
+ * Receives a service factory and returns an injection token. Only used in
+ * older versions of AngularJS that did not expose `.annotate`
+ * 
+ * Adapted from https://github.com/angular/angular.js/blob/0baa17a3b7ad2b242df2b277b81cebdf75b04287/src/auto/injector.js
+ **/
+Utils.annotate = function(fn) {
+	var $inject, fnText, argDecl;
 
-	var PREFIX_REGEXP = /^(x[\:\-_]|data[\:\-_])/i;
-	/**
-	 * Converts all accepted directives format into proper directive name.
-	 * All of these will become 'myDirective':
-	 *   my:Directive
-	 *   my-directive
-	 *   x-my-directive
-	 *   data-my:directive
-	 */
-	Utils.directiveNormalize = function(name) {
-		return NGI.Utils.camelCase(name.replace(PREFIX_REGEXP, ''));
-	}
-
-	/**
-	 * Receives a service factory and returns an injection token. Only used in
-	 * older versions of AngularJS that did not expose `.annotate`
-	 * 
-	 * Adapted from https://github.com/angular/angular.js/blob/0baa17a3b7ad2b242df2b277b81cebdf75b04287/src/auto/injector.js
-	 **/
-	Utils.annotate = function(fn) {
-		var $inject, fnText, argDecl;
-
-		if (typeof fn === 'function') {
-			if (!($inject = fn.$inject)) {
-				$inject = [];
-				if (fn.length) {
-					fnText = fn.toString().replace(STRIP_COMMENTS, '');
-					argDecl = fnText.match(FN_ARGS);
-					var argDecls = argDecl[1].split(FN_ARG_SPLIT);
-					for (var i = 0; i < argDecls.length; i++) {
-						var arg = argDecls[i];
-						arg.replace(FN_ARG, function(all, underscore, name) {
-							$inject.push(name);
-						});
-					};
-				}
-				fn.$inject = $inject;
+	if (typeof fn === 'function') {
+		if (!($inject = fn.$inject)) {
+			$inject = [];
+			if (fn.length) {
+				fnText = fn.toString().replace(STRIP_COMMENTS, '');
+				argDecl = fnText.match(FN_ARGS);
+				var argDecls = argDecl[1].split(FN_ARG_SPLIT);
+				for (var i = 0; i < argDecls.length; i++) {
+					var arg = argDecls[i];
+					arg.replace(FN_ARG, function(all, underscore, name) {
+						$inject.push(name);
+					});
+				};
 			}
-		} else if (Array.isArray(fn)) {
-			$inject = fn.slice(0, fn.length - 1);
-		} else {
-			return false;
+			fn.$inject = $inject;
 		}
-
-		return $inject;
+	} else if (Array.isArray(fn)) {
+		$inject = fn.slice(0, fn.length - 1);
+	} else {
+		return false;
 	}
 
-	return Utils;
+	return $inject;
+}
 
-})();
+module.exports = Utils;

--- a/src/js/bootstrap.js
+++ b/src/js/bootstrap.js
@@ -1,5 +1,7 @@
-/* global NGI, console */
-/* jshint strict: false */
+var NGI = {
+	Inspector: require('./Inspector'),
+	App: require('./App')
+};
 
 function bootstrap() {
 


### PR DESCRIPTION
- Introduced Browserify, so there is no longer an implicit dependency order on build files, and we don't need to maintain a list of JS files to build.

- Moved common JSHint options from individual files into a `.jshintrc`

All tests are passing, and I verified the extension works on a few sites in Chrome/Safari.