### PR TITLE
Check document.head before injecting script in Chrome

### DIFF
--- a/ng-inspector.chrome/inject.js
+++ b/ng-inspector.chrome/inject.js
@@ -1,4 +1,4 @@
-if (window.top === window) {
+if (window.top === window && document.head) {
 	
 	// Inject the bridge script
 	var inspectorScript = document.createElement('script');


### PR DESCRIPTION
When viewing a PDF file (and maybe in other cases?), Chrome passes a
document with document.head equal to null.  Without this check, this
causes the subsequent inspector injection script to throw an error.