### PR TITLE
Made the default text color black

### DIFF
--- a/src/less/stylesheet.less
+++ b/src/less/stylesheet.less
@@ -50,6 +50,7 @@ body {
 	background: #D8D8D8 !important;
 	border-left: 1px solid #B0B0B0 !important;
 	font-family: 'Helvetica Neue', sans-serif !important;
+	color: black;
 
 	/* Scrolling */
 	overflow-y: auto;


### PR DESCRIPTION
When the page has body {color:white} many of the titles are illegible (as they are inherit the color white)
See image for example
![screen shot 2015-08-19 at 14 41 01](https://cloud.githubusercontent.com/assets/614768/9357701/5c8c90d8-4680-11e5-81bf-97f1f666013b.png)
