### PR TITLE
Getter/Setter && Page Actions

### DIFF
--- a/ng-inspector.chrome/background.js
+++ b/ng-inspector.chrome/background.js
@@ -1,8 +1,14 @@
-chrome.browserAction.onClicked.addListener(function(tab) {
+chrome.pageAction.onClicked.addListener(function(tab) {
 	var message = {
 		command: 'ngi-toggle'
 	};
 	chrome.tabs.query({active: true, currentWindow: true}, function(tabs) {
 		chrome.tabs.sendMessage(tabs[0].id, message);
 	});
+});
+
+chrome.runtime.onMessage.addListener(function(msg, sender) {
+    if ((msg.from === 'content') && (msg.command === 'install-ngi-toggle')) {
+        chrome.pageAction.show(sender.tab.id);
+    }
 });

--- a/ng-inspector.chrome/inject.js
+++ b/ng-inspector.chrome/inject.js
@@ -4,15 +4,31 @@ if (window.top === window) {
 	var inspectorScript = document.createElement('script');
 	inspectorScript.type = 'text/javascript';
 	inspectorScript.src = chrome.extension.getURL('/ng-inspector.js');
-	document.head.appendChild(inspectorScript);
+	document.documentElement.appendChild(inspectorScript);
 
-	// In Chrome, we use this thing
-	if ('chrome' in window) {
-		chrome.runtime.onMessage.addListener(function(message, sender) {
-			if (message.command && message.command === 'ngi-toggle') {
-				window.postMessage(JSON.stringify(message), window.location.origin);
-			}
-		});
-	}
+	chrome.runtime.onMessage.addListener(function(message, sender) {
+		if (message.command && message.command === 'ngi-toggle') {
+			window.postMessage(JSON.stringify(message), window.location.origin);
+		}
+	});
 
+	window.addEventListener('message', function(evt) {
+		if (evt.origin !== window.location.origin) return;
+
+		var eventData = event.data;
+		if (!eventData || typeof eventData !== 'string') return;
+		try {
+			eventData = JSON.parse(eventData);
+		} catch(e) {
+			// Not a JSON object. Typically means another script on the page
+			// is using postMessage. Safe to ignore
+		}
+
+		if (eventData.command === 'ngi-angular-found') {
+			chrome.runtime.sendMessage({
+			    from:    'content',
+			    command: 'install-ngi-toggle'
+			});
+		}
+	});
 }

--- a/ng-inspector.chrome/manifest.json
+++ b/ng-inspector.chrome/manifest.json
@@ -18,7 +18,7 @@
     "48": "icon48.png",
     "128": "icon128.png"
   },
-  "browser_action": {
+  "page_action": {
     "default_icon": {
       "19": "btn19.png",
       "38": "btn38.png"
@@ -35,7 +35,8 @@
       ],
       "js": [
         "inject.js"
-      ]
+      ],
+      "run_at": "document_start"
     }
   ],
   "web_accessible_resources": [

--- a/ng-inspector.firefox/data/inject.js
+++ b/ng-inspector.firefox/data/inject.js
@@ -3,7 +3,7 @@ if (window.top === window) {
   var inspectorScript = document.createElement('script');
   inspectorScript.type = 'text/javascript';
   inspectorScript.src = self.options.ngInspectorURL;
-  document.head.appendChild(inspectorScript);
+  document.documentElement.appendChild(inspectorScript);
 
   // In Firefox, we use this thing
 

--- a/ng-inspector.firefox/lib/main.js
+++ b/ng-inspector.firefox/lib/main.js
@@ -61,6 +61,7 @@ var self = require("sdk/self");
 
 pageMod.PageMod({
   include: pageModConfig.include,
+  contentScriptWhen: 'start',
   contentScriptFile: pageModConfig.contentScriptFiles.map(function(path) {
     return self.data.url(path);
   }),

--- a/ng-inspector.safariextension/Info.plist
+++ b/ng-inspector.safariextension/Info.plist
@@ -46,9 +46,9 @@
     <dict>
       <key>Scripts</key>
       <dict>
-        <key>End</key>
+        <key>Start</key>
         <array>
-          <string>inject-end.js</string>
+          <string>inject.js</string>
         </array>
       </dict>
       <key>Stylesheets</key>

--- a/ng-inspector.safariextension/inject.js
+++ b/ng-inspector.safariextension/inject.js
@@ -4,7 +4,7 @@ if (window.top === window) {
 	var inspectorScript = document.createElement('script');
 	inspectorScript.type = 'text/javascript';
 	inspectorScript.src = safari.extension.baseURI + 'ng-inspector.js';
-	document.head.appendChild(inspectorScript);
+	document.documentElement.appendChild(inspectorScript);
 
 	// Forward the toggle event
 	safari.self.addEventListener('message', function(event) {

--- a/src/js/PublishEvent.js
+++ b/src/js/PublishEvent.js
@@ -1,0 +1,7 @@
+module.exports = function(command, payload, origin) {
+    var msg = JSON.stringify({
+        command: command,
+        payload: payload
+    });
+    window.postMessage(msg, origin || '*');
+};


### PR DESCRIPTION
This PR has 2 primary updates

1. It switches the extension to using a getter/setter to capture when angular is loaded, and hook bootstrapping. This is in contrast to our previous method, which listened for scripts being appended to the DOM and for `DOMContentLoaded`. While the old method created a race-case for how quickly we could patch bootstrapping, this new method ensures that we always wrap the `bootstrap` method *during* it's assignment.

2. The toggle button in Chrome has been switched to use a `pageAction`. It will now only show the toggle to a user (in the address bar of a tab) when Angular is present on the page.