### PR TITLE
Allows the inspector pane to be injected to pages opened locally

### DIFF
--- a/ng-inspector.chrome/manifest.json
+++ b/ng-inspector.chrome/manifest.json
@@ -28,7 +28,8 @@
   "content_scripts": [
     {
       "matches": [
-        "*://*/*"
+        "*://*/*",
+        "file:///*"
       ],
       "css": [
         "stylesheet.css"


### PR DESCRIPTION
Currently the chrome extension [manifest](https://github.com/rev087/ng-inspector/blob/master/ng-inspector.chrome/manifest.json) allows injecting the inspector pane to pages with a path that matches this pattern (*://*/*).

Adding the (file:///*) match pattern allows the extension to work properly on pages that are opened locally as well. (issue #40)