### PR TITLE
Associate shortcut key with toggle-inspector action

### DIFF
--- a/ng-inspector.safariextension/Info.plist
+++ b/ng-inspector.safariextension/Info.plist
@@ -44,17 +44,21 @@
     </dict>
     <key>Content</key>
     <dict>
-      <key>Scripts</key>
-      <dict>
-        <key>End</key>
+        <key>Scripts</key>
+        <dict>
+        	<key>End</key>
+        	<array>
+        		<string>inject-end.js</string>
+        	</array>
+        	<key>Start</key>
+        	<array>
+        		<string>keyboardShortcutHandler.js</string>
+        	</array>
+        </dict>
+        <key>Stylesheets</key>
         <array>
-          <string>inject-end.js</string>
+        	<string>stylesheet.css</string>
         </array>
-      </dict>
-      <key>Stylesheets</key>
-      <array>
-        <string>stylesheet.css</string>
-      </array>
     </dict>
     <key>Description</key>
     <string>Inspect the AngularJS scope hierarchy in a page.</string>

--- a/ng-inspector.safariextension/global.html
+++ b/ng-inspector.safariextension/global.html
@@ -9,6 +9,15 @@
 				safari.application.activeBrowserWindow.activeTab.page.dispatchMessage("toggle-inspector", {showWarnings:safari.extension.settings.showWarnings});
 			}
 		}, false);
+
+		// Listens to message from injected keyboardShortcutHandler.js
+		safari.application.addEventListener('message', handleKeyboardMessage, false);
+
+		// When message received, toggle inspector panel
+		function handleKeyboardMessage(e) {
+		    if (e.name == 'toggleInspector')
+				safari.application.activeBrowserWindow.activeTab.page.dispatchMessage("toggle-inspector", {showWarnings:safari.extension.settings.showWarnings});
+		}
 	</script>
 </head>
 <body>

--- a/ng-inspector.safariextension/keyboardShortcutHandler.js
+++ b/ng-inspector.safariextension/keyboardShortcutHandler.js
@@ -1,0 +1,11 @@
+// Listening for a keydown event
+window.addEventListener('keydown', handleKeydown, false);
+
+// Function to send message to Global.html when required shortcut detected
+function handleKeydown(e) {
+    // Watch for Cmd-Shift-I shortcut
+    if (e.keyCode == 73 && e.ctrlKey && e.metaKey) {
+        e.preventDefault();
+        safari.self.tab.dispatchMessage('toggleInspector');
+    }
+}


### PR DESCRIPTION
This change binds the Ctrl-Cmd-I keystroke to the toggle-inspector
action.